### PR TITLE
feat: Add `<NitroWebImage />` convenience view component

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,23 @@ function App() {
 }
 ```
 
+### The `<NitroWebImage />` view
+
+The `<NitroWebImage />` view is a JS-based React Native view component that fetches an `Image` from a remote URL as soon as it is mounted and displays it:
+
+```tsx
+function App() {
+  return (
+    <NitroWebImage
+      url="https://picsum.photos/seed/123/400"
+      placeholder={{ thumbHash: '…' }}
+      options={{ priority: 'high' }}
+      style={{ width: 400, height: 400 }}
+    />
+  )
+}
+```
+
 #### Dynamic width or height
 
 To achieve a dynamic width or height calculation, you can use the `image`'s dimensions:

--- a/src/NitroWebImage.tsx
+++ b/src/NitroWebImage.tsx
@@ -1,0 +1,81 @@
+import React, { useMemo } from 'react'
+import type { AsyncImageLoadOptions } from './specs/ImageFactory.nitro'
+import { useWebImage } from './useWebImage'
+import { NitroImage } from './NitroImage'
+import type { NitroImageViewProps } from './specs/ImageView.nitro'
+import type { Image } from './specs/Image.nitro'
+import { loadImageFromThumbHash } from './ImageFactory'
+import { thumbHashFromBase64String } from './ImageUtils'
+
+interface ImagePlaceholder {
+  image: Image
+}
+interface ThumbHashPlaceholder {
+  thumbHash: ArrayBuffer | string
+}
+interface ViewPlaceholder {
+  view: React.ReactElement
+}
+
+export interface NitroWebImageProps extends Omit<NitroImageViewProps, 'image'> {
+  url: string
+  options?: AsyncImageLoadOptions
+  placeholder?: ImagePlaceholder | ThumbHashPlaceholder | ViewPlaceholder
+}
+
+/**
+ * A renderable Image component that fetches the `Image` from the given URL,
+ * optionally displaying the given `placeholder` while fetching the image.
+ *
+ * As soon as this image is mounted, it will begin loading the image from the given URL.
+ */
+export function NitroWebImage({
+  url,
+  options,
+  placeholder,
+  ...props
+}: NitroWebImageProps) {
+  const image = useWebImage(url, options)
+  const placeholderImage = useMemo(() => {
+    if (placeholder == null) {
+      // We don't have a placeholder
+      return undefined
+    } else if ('image' in placeholder) {
+      // We have an in-memory Image as a placeholder
+      return placeholder.image
+    } else if ('thumbHash' in placeholder) {
+      // We have a thumbHash as a placeholder
+      let thumbHash = placeholder.thumbHash
+      if (typeof thumbHash === 'string') {
+        // It's a base64 string - convert to ArrayBuffer first
+        thumbHash = thumbHashFromBase64String(thumbHash)
+      }
+      return loadImageFromThumbHash(thumbHash)
+    } else {
+      // Unknown placeholder...
+      return undefined
+    }
+  }, [placeholder])
+
+  if (image == null) {
+    // It's still loading
+    if (placeholder == null) {
+      // No placeholder was specified by the user
+      return null
+    } else if (placeholderImage != null) {
+      // We have a placeholder image (thumbhash?)
+      return <NitroImage {...props} image={placeholderImage} />
+    } else if ('view' in placeholder) {
+      // We have a custom view as a placeholder
+      return placeholder.view
+    } else {
+      // This should never be reached
+      throw new Error(
+        `An unsupported placeholder was specified! ${placeholder}`
+      )
+    }
+  } else {
+    // It finished loading! Lets go
+    return <NitroImage {...props} image={image} />
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,8 @@ export type { Image } from './specs/Image.nitro'
  */
 export * from './ImageFactory'
 
-/**
- * The renderable native `<NitroImage />` view component.
- */
 export { NitroImage } from './NitroImage'
+export { NitroWebImage } from './NitroWebImage'
 
 /**
  * The `useWebImage` hook


### PR DESCRIPTION
Adds a convenience View component for displaying web images.

For power users it is recommended to create your own image component tailored for your use-case, but this is a general purpose solution that should work for most.