### PR TITLE
Fix Android Build on 0.80

### DIFF
--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridNitroImageViewManager.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/image/views/HybridNitroImageViewManager.kt
@@ -8,7 +8,6 @@
 package com.margelo.nitro.image.views
 
 import android.view.View
-import com.facebook.react.fabric.StateWrapperImpl
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.StateWrapper


### PR DESCRIPTION
We faced this issue on RN 0.80 build

Fabric `StateWrapperImpl` is now internal by React native.
However nitrogen/generated was still importing it .

