### PR TITLE
[feat] Support custom cache key

### DIFF
--- a/android/src/main/java/com/margelo/nitro/image/ImageRequestBuilder+applyOptions.kt
+++ b/android/src/main/java/com/margelo/nitro/image/ImageRequestBuilder+applyOptions.kt
@@ -12,14 +12,14 @@ suspend fun ImageRequest.Builder.applyOptions(options: AsyncImageLoadOptions?): 
     var result = this
 
     if (options.priority != null) {
-        result = result.coroutineContext(options.priority.toCoroutineContext())
+        result.coroutineContext(options.priority.toCoroutineContext())
     }
 
     if (options.forceRefresh == true) {
         // don't allow reading from cache, only writing.
-        result = result.diskCachePolicy(CachePolicy.WRITE_ONLY)
-        result = result.memoryCachePolicy(CachePolicy.WRITE_ONLY)
-        result = result.networkCachePolicy(CachePolicy.WRITE_ONLY)
+        result.diskCachePolicy(CachePolicy.WRITE_ONLY)
+            .memoryCachePolicy(CachePolicy.WRITE_ONLY)
+            .networkCachePolicy(CachePolicy.WRITE_ONLY)
     }
 
     if (options.continueInBackground == true) {
@@ -32,8 +32,8 @@ suspend fun ImageRequest.Builder.applyOptions(options: AsyncImageLoadOptions?): 
 
     if (options.scaleDownLargeImages == true) {
         // Limit to 4096x4096 (~60 MB)
-        result = result.size(4096, 4096)
-        result = result.precision(Precision.INEXACT)
+        result.size(4096, 4096)
+            .precision(Precision.INEXACT)
     }
 
     if (options.queryMemoryDataSync == true) {
@@ -45,8 +45,11 @@ suspend fun ImageRequest.Builder.applyOptions(options: AsyncImageLoadOptions?): 
     }
 
     if (options.decodeImage == false) {
-        result = result.decoderFactory(BlackholeDecoder.Factory())
+        result.decoderFactory(BlackholeDecoder.Factory())
     }
 
+    if (options.cacheKey != null) {
+        result.diskCacheKey(options.cacheKey)
+    }
     return result
 }

--- a/example/src/NitroImageTab.tsx
+++ b/example/src/NitroImageTab.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { FlatList, Text, View } from "react-native";
+import React, { useMemo } from "react";
+import { FlatList, StyleSheet, Text, View } from "react-native";
 import { NitroWebImage } from "react-native-nitro-image";
 import { createImageURLs } from "./createImageURLs";
 
@@ -7,16 +7,30 @@ export function NitroImageTab() {
     const imageURLs = useMemo(() => createImageURLs(), []);
 
     return (
-        <View>
-            <Text>NitroImage Tab</Text>
-            <FlatList
-                numColumns={4}
-                windowSize={3}
-                data={imageURLs}
-                renderItem={({ item: url }) => (
-                    <NitroWebImage url={url} resizeMode="cover" />
-                )}
+      <View>
+        <Text>NitroImage Tab</Text>
+        <FlatList
+          numColumns={4}
+          windowSize={3}
+          data={imageURLs}
+          renderItem={({ item: url }) => (
+            <NitroWebImage
+              style={styles.image}
+              url={url}
+              resizeMode="cover"
+              options={{
+                cacheKey: 'test-custom-cache-key',
+              }}
             />
-        </View>
-    );
+          )}
+        />
+      </View>
+    )
 }
+
+const styles = StyleSheet.create({
+    image: {
+        width: "25%",
+        aspectRatio: 1,
+    },
+});

--- a/ios/AsyncImageLoadOptions+toSDWebImageOptions.swift
+++ b/ios/AsyncImageLoadOptions+toSDWebImageOptions.swift
@@ -51,4 +51,16 @@ extension AsyncImageLoadOptions {
     
     return options
   }
+
+  func toSDWebImageContext() -> [SDWebImageContextOption: Any] {
+    var context: [SDWebImageContextOption: Any] = [:]
+
+    if let customCacheKey = cacheKey {
+      context[.cacheKeyFilter] = SDWebImageCacheKeyFilter { _ in
+        return customCacheKey
+      }
+    }
+
+    return context
+  }
 }

--- a/ios/HybridImageFactory.swift
+++ b/ios/HybridImageFactory.swift
@@ -24,7 +24,8 @@ class HybridImageFactory: HybridImageFactorySpec {
 
     return Promise.async {
       let webImageOptions = options?.toSDWebImageOptions() ?? []
-      let uiImage = try await SDWebImageManager.shared.loadImage(with: url, options: webImageOptions)
+      let webImageContext = options?.toSDWebImageContext() ?? [:]
+      let uiImage = try await SDWebImageManager.shared.loadImage(with: url, options: webImageOptions, context: webImageContext)
       return HybridImage(uiImage: uiImage)
     }
   }

--- a/ios/SDWebImageManager+loadImage.swift
+++ b/ios/SDWebImageManager+loadImage.swift
@@ -10,9 +10,9 @@ import SDWebImage
 import NitroModules
 
 extension SDWebImageManager {
-  func loadImage(with url: URL, options: SDWebImageOptions) async throws -> UIImage {
+  func loadImage(with url: URL, options: SDWebImageOptions, context: [SDWebImageContextOption: Any]?) async throws -> UIImage {
     return try await withUnsafeThrowingContinuation { continuation in
-      self.loadImage(with: url, options: options) { current, total, url in
+      self.loadImage(with: url, options: options, context: context) { current, total, url in
         print("\(url): Loaded \(current)/\(total) bytes")
       } completed: { image, data, error, cacheType, finished, url in
         if let image {

--- a/nitrogen/generated/android/c++/JAsyncImageLoadOptions.hpp
+++ b/nitrogen/generated/android/c++/JAsyncImageLoadOptions.hpp
@@ -13,6 +13,7 @@
 #include "AsyncImagePriority.hpp"
 #include "JAsyncImagePriority.hpp"
 #include <optional>
+#include <string>
 
 namespace margelo::nitro::image {
 
@@ -37,6 +38,8 @@ namespace margelo::nitro::image {
       jni::local_ref<JAsyncImagePriority> priority = this->getFieldValue(fieldPriority);
       static const auto fieldForceRefresh = clazz->getField<jni::JBoolean>("forceRefresh");
       jni::local_ref<jni::JBoolean> forceRefresh = this->getFieldValue(fieldForceRefresh);
+      static const auto fieldCacheKey = clazz->getField<jni::JString>("cacheKey");
+      jni::local_ref<jni::JString> cacheKey = this->getFieldValue(fieldCacheKey);
       static const auto fieldContinueInBackground = clazz->getField<jni::JBoolean>("continueInBackground");
       jni::local_ref<jni::JBoolean> continueInBackground = this->getFieldValue(fieldContinueInBackground);
       static const auto fieldAllowInvalidSSLCertificates = clazz->getField<jni::JBoolean>("allowInvalidSSLCertificates");
@@ -52,6 +55,7 @@ namespace margelo::nitro::image {
       return AsyncImageLoadOptions(
         priority != nullptr ? std::make_optional(priority->toCpp()) : std::nullopt,
         forceRefresh != nullptr ? std::make_optional(static_cast<bool>(forceRefresh->value())) : std::nullopt,
+        cacheKey != nullptr ? std::make_optional(cacheKey->toStdString()) : std::nullopt,
         continueInBackground != nullptr ? std::make_optional(static_cast<bool>(continueInBackground->value())) : std::nullopt,
         allowInvalidSSLCertificates != nullptr ? std::make_optional(static_cast<bool>(allowInvalidSSLCertificates->value())) : std::nullopt,
         scaleDownLargeImages != nullptr ? std::make_optional(static_cast<bool>(scaleDownLargeImages->value())) : std::nullopt,
@@ -70,6 +74,7 @@ namespace margelo::nitro::image {
       return newInstance(
         value.priority.has_value() ? JAsyncImagePriority::fromCpp(value.priority.value()) : nullptr,
         value.forceRefresh.has_value() ? jni::JBoolean::valueOf(value.forceRefresh.value()) : nullptr,
+        value.cacheKey.has_value() ? jni::make_jstring(value.cacheKey.value()) : nullptr,
         value.continueInBackground.has_value() ? jni::JBoolean::valueOf(value.continueInBackground.value()) : nullptr,
         value.allowInvalidSSLCertificates.has_value() ? jni::JBoolean::valueOf(value.allowInvalidSSLCertificates.value()) : nullptr,
         value.scaleDownLargeImages.has_value() ? jni::JBoolean::valueOf(value.scaleDownLargeImages.value()) : nullptr,

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/image/AsyncImageLoadOptions.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/image/AsyncImageLoadOptions.kt
@@ -22,6 +22,7 @@ data class AsyncImageLoadOptions
   constructor(
     val priority: AsyncImagePriority?,
     val forceRefresh: Boolean?,
+    val cacheKey: String?,
     val continueInBackground: Boolean?,
     val allowInvalidSSLCertificates: Boolean?,
     val scaleDownLargeImages: Boolean?,

--- a/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -304,6 +304,15 @@ namespace margelo::nitro::image::bridge::swift {
     return std::optional<bool>(value);
   }
   
+  // pragma MARK: std::optional<std::string>
+  /**
+   * Specialized version of `std::optional<std::string>`.
+   */
+  using std__optional_std__string_ = std::optional<std::string>;
+  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) {
+    return std::optional<std::string>(value);
+  }
+  
   // pragma MARK: std::optional<AsyncImageLoadOptions>
   /**
    * Specialized version of `std::optional<AsyncImageLoadOptions>`.

--- a/nitrogen/generated/ios/swift/AsyncImageLoadOptions.swift
+++ b/nitrogen/generated/ios/swift/AsyncImageLoadOptions.swift
@@ -18,7 +18,7 @@ public extension AsyncImageLoadOptions {
   /**
    * Create a new instance of `AsyncImageLoadOptions`.
    */
-  init(priority: AsyncImagePriority?, forceRefresh: Bool?, continueInBackground: Bool?, allowInvalidSSLCertificates: Bool?, scaleDownLargeImages: Bool?, queryMemoryDataSync: Bool?, queryDiskDataSync: Bool?, decodeImage: Bool?) {
+  init(priority: AsyncImagePriority?, forceRefresh: Bool?, cacheKey: String?, continueInBackground: Bool?, allowInvalidSSLCertificates: Bool?, scaleDownLargeImages: Bool?, queryMemoryDataSync: Bool?, queryDiskDataSync: Bool?, decodeImage: Bool?) {
     self.init({ () -> bridge.std__optional_AsyncImagePriority_ in
       if let __unwrappedValue = priority {
         return bridge.create_std__optional_AsyncImagePriority_(__unwrappedValue)
@@ -28,6 +28,12 @@ public extension AsyncImageLoadOptions {
     }(), { () -> bridge.std__optional_bool_ in
       if let __unwrappedValue = forceRefresh {
         return bridge.create_std__optional_bool_(__unwrappedValue)
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_std__string_ in
+      if let __unwrappedValue = cacheKey {
+        return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
       } else {
         return .init()
       }
@@ -97,6 +103,29 @@ public extension AsyncImageLoadOptions {
       self.__forceRefresh = { () -> bridge.std__optional_bool_ in
         if let __unwrappedValue = newValue {
           return bridge.create_std__optional_bool_(__unwrappedValue)
+        } else {
+          return .init()
+        }
+      }()
+    }
+  }
+  
+  var cacheKey: String? {
+    @inline(__always)
+    get {
+      return { () -> String? in
+        if let __unwrapped = self.__cacheKey.value {
+          return String(__unwrapped)
+        } else {
+          return nil
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__cacheKey = { () -> bridge.std__optional_std__string_ in
+        if let __unwrappedValue = newValue {
+          return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
         } else {
           return .init()
         }

--- a/nitrogen/generated/shared/c++/AsyncImageLoadOptions.hpp
+++ b/nitrogen/generated/shared/c++/AsyncImageLoadOptions.hpp
@@ -23,6 +23,7 @@ namespace margelo::nitro::image { enum class AsyncImagePriority; }
 
 #include <optional>
 #include "AsyncImagePriority.hpp"
+#include <string>
 
 namespace margelo::nitro::image {
 
@@ -33,6 +34,7 @@ namespace margelo::nitro::image {
   public:
     std::optional<AsyncImagePriority> priority     SWIFT_PRIVATE;
     std::optional<bool> forceRefresh     SWIFT_PRIVATE;
+    std::optional<std::string> cacheKey     SWIFT_PRIVATE;
     std::optional<bool> continueInBackground     SWIFT_PRIVATE;
     std::optional<bool> allowInvalidSSLCertificates     SWIFT_PRIVATE;
     std::optional<bool> scaleDownLargeImages     SWIFT_PRIVATE;
@@ -42,7 +44,7 @@ namespace margelo::nitro::image {
 
   public:
     AsyncImageLoadOptions() = default;
-    explicit AsyncImageLoadOptions(std::optional<AsyncImagePriority> priority, std::optional<bool> forceRefresh, std::optional<bool> continueInBackground, std::optional<bool> allowInvalidSSLCertificates, std::optional<bool> scaleDownLargeImages, std::optional<bool> queryMemoryDataSync, std::optional<bool> queryDiskDataSync, std::optional<bool> decodeImage): priority(priority), forceRefresh(forceRefresh), continueInBackground(continueInBackground), allowInvalidSSLCertificates(allowInvalidSSLCertificates), scaleDownLargeImages(scaleDownLargeImages), queryMemoryDataSync(queryMemoryDataSync), queryDiskDataSync(queryDiskDataSync), decodeImage(decodeImage) {}
+    explicit AsyncImageLoadOptions(std::optional<AsyncImagePriority> priority, std::optional<bool> forceRefresh, std::optional<std::string> cacheKey, std::optional<bool> continueInBackground, std::optional<bool> allowInvalidSSLCertificates, std::optional<bool> scaleDownLargeImages, std::optional<bool> queryMemoryDataSync, std::optional<bool> queryDiskDataSync, std::optional<bool> decodeImage): priority(priority), forceRefresh(forceRefresh), cacheKey(cacheKey), continueInBackground(continueInBackground), allowInvalidSSLCertificates(allowInvalidSSLCertificates), scaleDownLargeImages(scaleDownLargeImages), queryMemoryDataSync(queryMemoryDataSync), queryDiskDataSync(queryDiskDataSync), decodeImage(decodeImage) {}
   };
 
 } // namespace margelo::nitro::image
@@ -59,6 +61,7 @@ namespace margelo::nitro {
       return AsyncImageLoadOptions(
         JSIConverter<std::optional<AsyncImagePriority>>::fromJSI(runtime, obj.getProperty(runtime, "priority")),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, "forceRefresh")),
+        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, "cacheKey")),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, "continueInBackground")),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, "allowInvalidSSLCertificates")),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, "scaleDownLargeImages")),
@@ -71,6 +74,7 @@ namespace margelo::nitro {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, "priority", JSIConverter<std::optional<AsyncImagePriority>>::toJSI(runtime, arg.priority));
       obj.setProperty(runtime, "forceRefresh", JSIConverter<std::optional<bool>>::toJSI(runtime, arg.forceRefresh));
+      obj.setProperty(runtime, "cacheKey", JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.cacheKey));
       obj.setProperty(runtime, "continueInBackground", JSIConverter<std::optional<bool>>::toJSI(runtime, arg.continueInBackground));
       obj.setProperty(runtime, "allowInvalidSSLCertificates", JSIConverter<std::optional<bool>>::toJSI(runtime, arg.allowInvalidSSLCertificates));
       obj.setProperty(runtime, "scaleDownLargeImages", JSIConverter<std::optional<bool>>::toJSI(runtime, arg.scaleDownLargeImages));
@@ -86,6 +90,7 @@ namespace margelo::nitro {
       jsi::Object obj = value.getObject(runtime);
       if (!JSIConverter<std::optional<AsyncImagePriority>>::canConvert(runtime, obj.getProperty(runtime, "priority"))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, "forceRefresh"))) return false;
+      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, "cacheKey"))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, "continueInBackground"))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, "allowInvalidSSLCertificates"))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, "scaleDownLargeImages"))) return false;

--- a/src/NitroWebImage.tsx
+++ b/src/NitroWebImage.tsx
@@ -5,6 +5,7 @@ import { NitroImage } from "./NitroImage";
 import type { Image } from "./specs/Image.nitro";
 import type { AsyncImageLoadOptions } from "./specs/ImageFactory.nitro";
 import type { NitroImageViewProps } from "./specs/ImageView.nitro";
+import type { StyleProp, ViewStyle } from "react-native";
 import { useWebImage } from "./useWebImage";
 
 interface ImagePlaceholder {
@@ -18,6 +19,7 @@ interface ViewPlaceholder {
 }
 
 export interface NitroWebImageProps extends Omit<NitroImageViewProps, "image"> {
+    style?: StyleProp<ViewStyle>;
     url: string;
     options?: AsyncImageLoadOptions;
     placeholder?: ImagePlaceholder | ThumbHashPlaceholder | ViewPlaceholder;

--- a/src/specs/ImageFactory.nitro.ts
+++ b/src/specs/ImageFactory.nitro.ts
@@ -18,6 +18,12 @@ export interface AsyncImageLoadOptions {
     forceRefresh?: boolean;
 
     /**
+     * A custom cache key to use for the image.
+     * @default The URL of the image.
+     */
+    cacheKey?: string;
+
+    /**
      * Allows the Image download to continue even when the app is backgrounded.
      * @default false
      */


### PR DESCRIPTION
## Description
This PR introduced new prop for custom cache key for image loading operation. Default key is the image's url

## Usage
### NitroWebImage
```
<NitroWebImage
    style={styles.image}
    url={url}
    resizeMode="cover"
    options={{
      cacheKey: 'test-custom-cache-key',
    }}
/>
```
### loadImageFromURLAsync
```
loadImageFromURLAsync(url, {
  cacheKey: 'test-custom-cache-key',
})
```
## Testing
Updated the example with 1 cache key. Expected all the image show the same image
```
<NitroWebImage
    style={styles.image}
    url={url}
    resizeMode="cover"
    options={{
      cacheKey: 'test-custom-cache-key',
    }}
  />
```
| android               | ios                                       | 
|---------|------------------------------|
| <img src="https://github.com/user-attachments/assets/f29495f6-b79b-4abe-9c0a-2dfd1f917ff2" width="200" />  | <img src="https://github.com/user-attachments/assets/74e277fb-e141-4866-aac5-0df45c1f367f" width="200" />|
