### PR TITLE
feat: Add `cacheKey`

### DIFF
--- a/packages/react-native-nitro-web-image/android/src/main/java/com/margelo/nitro/web/image/ImageRequestBuilder+applyOptions.kt
+++ b/packages/react-native-nitro-web-image/android/src/main/java/com/margelo/nitro/web/image/ImageRequestBuilder+applyOptions.kt
@@ -50,5 +50,9 @@ fun ImageRequest.Builder.applyOptions(options: AsyncImageLoadOptions?): ImageReq
         result = result.decoderFactory(BlackholeDecoder.Factory())
     }
 
+    if (options.cacheKey != null) {
+        result = result.diskCacheKey(options.cacheKey)
+    }
+
     return result
 }

--- a/packages/react-native-nitro-web-image/ios/AsyncImageLoadOptions+toSDWebImageOptions.swift
+++ b/packages/react-native-nitro-web-image/ios/AsyncImageLoadOptions+toSDWebImageOptions.swift
@@ -51,4 +51,16 @@ extension AsyncImageLoadOptions {
 
     return options
   }
+
+  func toSDWebImageContext() -> [SDWebImageContextOption: Any] {
+    var context: [SDWebImageContextOption: Any] = [:]
+
+    if let cacheKey {
+      context[.cacheKeyFilter] = SDWebImageCacheKeyFilter { _ in
+        return cacheKey
+      }
+    }
+
+    return context
+  }
 }

--- a/packages/react-native-nitro-web-image/ios/HybridWebImageLoader.swift
+++ b/packages/react-native-nitro-web-image/ios/HybridWebImageLoader.swift
@@ -30,7 +30,10 @@ class HybridWebImageLoader: HybridImageLoaderSpec {
   func loadImage() throws -> Promise<(any HybridImageSpec)> {
     return Promise.async {
       let webImageOptions = self.options?.toSDWebImageOptions() ?? []
-      let uiImage = try await SDWebImageManager.shared.loadImage(with: self.url, options: webImageOptions)
+      let webImageContext = self.options?.toSDWebImageContext() ?? [:]
+      let uiImage = try await SDWebImageManager.shared.loadImage(with: self.url,
+                                                                 options: webImageOptions,
+                                                                 context: webImageContext)
       return HybridImage(uiImage: uiImage)
     }
   }

--- a/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JAsyncImageLoadOptions.hpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JAsyncImageLoadOptions.hpp
@@ -13,6 +13,7 @@
 #include "AsyncImagePriority.hpp"
 #include "JAsyncImagePriority.hpp"
 #include <optional>
+#include <string>
 
 namespace margelo::nitro::web::image {
 
@@ -37,6 +38,8 @@ namespace margelo::nitro::web::image {
       jni::local_ref<JAsyncImagePriority> priority = this->getFieldValue(fieldPriority);
       static const auto fieldForceRefresh = clazz->getField<jni::JBoolean>("forceRefresh");
       jni::local_ref<jni::JBoolean> forceRefresh = this->getFieldValue(fieldForceRefresh);
+      static const auto fieldCacheKey = clazz->getField<jni::JString>("cacheKey");
+      jni::local_ref<jni::JString> cacheKey = this->getFieldValue(fieldCacheKey);
       static const auto fieldContinueInBackground = clazz->getField<jni::JBoolean>("continueInBackground");
       jni::local_ref<jni::JBoolean> continueInBackground = this->getFieldValue(fieldContinueInBackground);
       static const auto fieldAllowInvalidSSLCertificates = clazz->getField<jni::JBoolean>("allowInvalidSSLCertificates");
@@ -52,6 +55,7 @@ namespace margelo::nitro::web::image {
       return AsyncImageLoadOptions(
         priority != nullptr ? std::make_optional(priority->toCpp()) : std::nullopt,
         forceRefresh != nullptr ? std::make_optional(static_cast<bool>(forceRefresh->value())) : std::nullopt,
+        cacheKey != nullptr ? std::make_optional(cacheKey->toStdString()) : std::nullopt,
         continueInBackground != nullptr ? std::make_optional(static_cast<bool>(continueInBackground->value())) : std::nullopt,
         allowInvalidSSLCertificates != nullptr ? std::make_optional(static_cast<bool>(allowInvalidSSLCertificates->value())) : std::nullopt,
         scaleDownLargeImages != nullptr ? std::make_optional(static_cast<bool>(scaleDownLargeImages->value())) : std::nullopt,
@@ -70,6 +74,7 @@ namespace margelo::nitro::web::image {
       return newInstance(
         value.priority.has_value() ? JAsyncImagePriority::fromCpp(value.priority.value()) : nullptr,
         value.forceRefresh.has_value() ? jni::JBoolean::valueOf(value.forceRefresh.value()) : nullptr,
+        value.cacheKey.has_value() ? jni::make_jstring(value.cacheKey.value()) : nullptr,
         value.continueInBackground.has_value() ? jni::JBoolean::valueOf(value.continueInBackground.value()) : nullptr,
         value.allowInvalidSSLCertificates.has_value() ? jni::JBoolean::valueOf(value.allowInvalidSSLCertificates.value()) : nullptr,
         value.scaleDownLargeImages.has_value() ? jni::JBoolean::valueOf(value.scaleDownLargeImages.value()) : nullptr,

--- a/packages/react-native-nitro-web-image/nitrogen/generated/android/kotlin/com/margelo/nitro/web/image/AsyncImageLoadOptions.kt
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/android/kotlin/com/margelo/nitro/web/image/AsyncImageLoadOptions.kt
@@ -23,6 +23,7 @@ data class AsyncImageLoadOptions
   constructor(
     val priority: AsyncImagePriority?,
     val forceRefresh: Boolean?,
+    val cacheKey: String?,
     val continueInBackground: Boolean?,
     val allowInvalidSSLCertificates: Boolean?,
     val scaleDownLargeImages: Boolean?,

--- a/packages/react-native-nitro-web-image/nitrogen/generated/ios/NitroWebImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/ios/NitroWebImage-Swift-Cxx-Bridge.hpp
@@ -40,6 +40,7 @@ namespace NitroWebImage { class HybridWebImageFactorySpec_cxx; }
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 
 /**
  * Contains specialized versions of C++ templated types so they can be accessed from Swift,
@@ -75,6 +76,15 @@ namespace margelo::nitro::web::image::bridge::swift {
   using std__optional_bool_ = std::optional<bool>;
   inline std::optional<bool> create_std__optional_bool_(const bool& value) {
     return std::optional<bool>(value);
+  }
+  
+  // pragma MARK: std::optional<std::string>
+  /**
+   * Specialized version of `std::optional<std::string>`.
+   */
+  using std__optional_std__string_ = std::optional<std::string>;
+  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) {
+    return std::optional<std::string>(value);
   }
   
   // pragma MARK: std::optional<AsyncImageLoadOptions>

--- a/packages/react-native-nitro-web-image/nitrogen/generated/ios/swift/AsyncImageLoadOptions.swift
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/ios/swift/AsyncImageLoadOptions.swift
@@ -18,7 +18,7 @@ public extension AsyncImageLoadOptions {
   /**
    * Create a new instance of `AsyncImageLoadOptions`.
    */
-  init(priority: AsyncImagePriority?, forceRefresh: Bool?, continueInBackground: Bool?, allowInvalidSSLCertificates: Bool?, scaleDownLargeImages: Bool?, queryMemoryDataSync: Bool?, queryDiskDataSync: Bool?, decodeImage: Bool?) {
+  init(priority: AsyncImagePriority?, forceRefresh: Bool?, cacheKey: String?, continueInBackground: Bool?, allowInvalidSSLCertificates: Bool?, scaleDownLargeImages: Bool?, queryMemoryDataSync: Bool?, queryDiskDataSync: Bool?, decodeImage: Bool?) {
     self.init({ () -> bridge.std__optional_AsyncImagePriority_ in
       if let __unwrappedValue = priority {
         return bridge.create_std__optional_AsyncImagePriority_(__unwrappedValue)
@@ -28,6 +28,12 @@ public extension AsyncImageLoadOptions {
     }(), { () -> bridge.std__optional_bool_ in
       if let __unwrappedValue = forceRefresh {
         return bridge.create_std__optional_bool_(__unwrappedValue)
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_std__string_ in
+      if let __unwrappedValue = cacheKey {
+        return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
       } else {
         return .init()
       }
@@ -97,6 +103,29 @@ public extension AsyncImageLoadOptions {
       self.__forceRefresh = { () -> bridge.std__optional_bool_ in
         if let __unwrappedValue = newValue {
           return bridge.create_std__optional_bool_(__unwrappedValue)
+        } else {
+          return .init()
+        }
+      }()
+    }
+  }
+  
+  var cacheKey: String? {
+    @inline(__always)
+    get {
+      return { () -> String? in
+        if let __unwrapped = self.__cacheKey.value {
+          return String(__unwrapped)
+        } else {
+          return nil
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__cacheKey = { () -> bridge.std__optional_std__string_ in
+        if let __unwrappedValue = newValue {
+          return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
         } else {
           return .init()
         }

--- a/packages/react-native-nitro-web-image/nitrogen/generated/shared/c++/AsyncImageLoadOptions.hpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/shared/c++/AsyncImageLoadOptions.hpp
@@ -23,6 +23,7 @@ namespace margelo::nitro::web::image { enum class AsyncImagePriority; }
 
 #include "AsyncImagePriority.hpp"
 #include <optional>
+#include <string>
 
 namespace margelo::nitro::web::image {
 
@@ -33,6 +34,7 @@ namespace margelo::nitro::web::image {
   public:
     std::optional<AsyncImagePriority> priority     SWIFT_PRIVATE;
     std::optional<bool> forceRefresh     SWIFT_PRIVATE;
+    std::optional<std::string> cacheKey     SWIFT_PRIVATE;
     std::optional<bool> continueInBackground     SWIFT_PRIVATE;
     std::optional<bool> allowInvalidSSLCertificates     SWIFT_PRIVATE;
     std::optional<bool> scaleDownLargeImages     SWIFT_PRIVATE;
@@ -42,7 +44,7 @@ namespace margelo::nitro::web::image {
 
   public:
     AsyncImageLoadOptions() = default;
-    explicit AsyncImageLoadOptions(std::optional<AsyncImagePriority> priority, std::optional<bool> forceRefresh, std::optional<bool> continueInBackground, std::optional<bool> allowInvalidSSLCertificates, std::optional<bool> scaleDownLargeImages, std::optional<bool> queryMemoryDataSync, std::optional<bool> queryDiskDataSync, std::optional<bool> decodeImage): priority(priority), forceRefresh(forceRefresh), continueInBackground(continueInBackground), allowInvalidSSLCertificates(allowInvalidSSLCertificates), scaleDownLargeImages(scaleDownLargeImages), queryMemoryDataSync(queryMemoryDataSync), queryDiskDataSync(queryDiskDataSync), decodeImage(decodeImage) {}
+    explicit AsyncImageLoadOptions(std::optional<AsyncImagePriority> priority, std::optional<bool> forceRefresh, std::optional<std::string> cacheKey, std::optional<bool> continueInBackground, std::optional<bool> allowInvalidSSLCertificates, std::optional<bool> scaleDownLargeImages, std::optional<bool> queryMemoryDataSync, std::optional<bool> queryDiskDataSync, std::optional<bool> decodeImage): priority(priority), forceRefresh(forceRefresh), cacheKey(cacheKey), continueInBackground(continueInBackground), allowInvalidSSLCertificates(allowInvalidSSLCertificates), scaleDownLargeImages(scaleDownLargeImages), queryMemoryDataSync(queryMemoryDataSync), queryDiskDataSync(queryDiskDataSync), decodeImage(decodeImage) {}
   };
 
 } // namespace margelo::nitro::web::image
@@ -59,6 +61,7 @@ namespace margelo::nitro {
       return AsyncImageLoadOptions(
         JSIConverter<std::optional<AsyncImagePriority>>::fromJSI(runtime, obj.getProperty(runtime, "priority")),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, "forceRefresh")),
+        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, "cacheKey")),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, "continueInBackground")),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, "allowInvalidSSLCertificates")),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, "scaleDownLargeImages")),
@@ -71,6 +74,7 @@ namespace margelo::nitro {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, "priority", JSIConverter<std::optional<AsyncImagePriority>>::toJSI(runtime, arg.priority));
       obj.setProperty(runtime, "forceRefresh", JSIConverter<std::optional<bool>>::toJSI(runtime, arg.forceRefresh));
+      obj.setProperty(runtime, "cacheKey", JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.cacheKey));
       obj.setProperty(runtime, "continueInBackground", JSIConverter<std::optional<bool>>::toJSI(runtime, arg.continueInBackground));
       obj.setProperty(runtime, "allowInvalidSSLCertificates", JSIConverter<std::optional<bool>>::toJSI(runtime, arg.allowInvalidSSLCertificates));
       obj.setProperty(runtime, "scaleDownLargeImages", JSIConverter<std::optional<bool>>::toJSI(runtime, arg.scaleDownLargeImages));
@@ -86,6 +90,7 @@ namespace margelo::nitro {
       jsi::Object obj = value.getObject(runtime);
       if (!JSIConverter<std::optional<AsyncImagePriority>>::canConvert(runtime, obj.getProperty(runtime, "priority"))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, "forceRefresh"))) return false;
+      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, "cacheKey"))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, "continueInBackground"))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, "allowInvalidSSLCertificates"))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, "scaleDownLargeImages"))) return false;

--- a/packages/react-native-nitro-web-image/src/specs/WebImageFactory.nitro.ts
+++ b/packages/react-native-nitro-web-image/src/specs/WebImageFactory.nitro.ts
@@ -18,6 +18,13 @@ export interface AsyncImageLoadOptions {
     forceRefresh?: boolean;
 
     /**
+     * A custom cache key to use for the image. By default, the URL is used as a cache key.
+     * For customized access control/caching, provide a custom cache key.
+     * @default The URL of the image.
+     */
+    cacheKey?: string;
+
+    /**
      * Allows the Image download to continue even when the app is backgrounded.
      * @default false
      */


### PR DESCRIPTION
Adds a `cacheKey` property. By default, the URL is used.

Based on https://github.com/mrousavy/react-native-nitro-image/pull/22/, but adjusted after the rewrite