### PR TITLE
feat: Add `recyclingKey`

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
@@ -7,6 +7,9 @@ import android.widget.ImageView
 import androidx.annotation.Keep
 import androidx.core.view.isVisible
 import com.facebook.common.internal.DoNotStrip
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 @DoNotStrip
 @Keep
@@ -14,29 +17,46 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec() {
     companion object {
         private const val TAG = "HybridImageView"
     }
-    override var resizeMode: ResizeMode? = ResizeMode.CONTAIN
-        set(value) {
-            field = value
-            imageView.scaleType = when (value) {
-                ResizeMode.COVER -> ImageView.ScaleType.CENTER_CROP
-                ResizeMode.CONTAIN -> ImageView.ScaleType.FIT_CENTER
-                ResizeMode.STRETCH -> ImageView.ScaleType.FIT_XY
-                ResizeMode.CENTER -> ImageView.ScaleType.CENTER
-                null -> ImageView.ScaleType.CENTER_CROP
-            }
-        }
-
-    override var image: Variant_HybridImageSpec_HybridImageLoaderSpec? = null
-        set(value) {
-            field = value
-            updateImage()
-        }
+    private val uiScope = CoroutineScope(Dispatchers.Main)
+    private var resetImageBeforeLoad = false
 
     val imageView = CustomImageView(context) { visible ->
         if (visible) onAppear()
         else onDisappear()
     }
     override val view: View = imageView
+
+    override var resizeMode: ResizeMode? = ResizeMode.CONTAIN
+        set(value) {
+            field = value
+            uiScope.launch {
+                updateResizeMode()
+            }
+        }
+
+    override var image: Variant_HybridImageSpec_HybridImageLoaderSpec? = null
+        set(value) {
+            field = value
+            uiScope.launch {
+                updateImage()
+            }
+        }
+
+    override var recyclingKey: String? = null
+        set(value) {
+            resetImageBeforeLoad = field != value
+            field = value
+        }
+
+    private fun updateResizeMode() {
+        imageView.scaleType = when (resizeMode) {
+            ResizeMode.COVER -> ImageView.ScaleType.CENTER_CROP
+            ResizeMode.CONTAIN -> ImageView.ScaleType.FIT_CENTER
+            ResizeMode.STRETCH -> ImageView.ScaleType.FIT_XY
+            ResizeMode.CENTER -> ImageView.ScaleType.CENTER
+            null -> ImageView.ScaleType.CENTER_CROP
+        }
+    }
 
     private fun updateImage() {
         val image = image ?: return
@@ -60,6 +80,10 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec() {
         val image = image ?: return
         val imageLoader = image.getAs<HybridImageLoaderSpec>() ?: return
         try {
+            if (resetImageBeforeLoad) {
+                imageView.setImageDrawable(null)
+                resetImageBeforeLoad = false
+            }
             imageLoader.requestImage(this)
         } catch (e: Throwable) {
             Log.e(TAG, "Failed to request Image!", e)

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridNitroImageViewSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridNitroImageViewSpec.cpp
@@ -25,6 +25,7 @@ namespace margelo::nitro::image { enum class ResizeMode; }
 #include "JHybridImageLoaderSpec.hpp"
 #include "ResizeMode.hpp"
 #include "JResizeMode.hpp"
+#include <string>
 
 namespace margelo::nitro::image {
 
@@ -66,6 +67,15 @@ namespace margelo::nitro::image {
   void JHybridNitroImageViewSpec::setResizeMode(std::optional<ResizeMode> resizeMode) {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JResizeMode> /* resizeMode */)>("setResizeMode");
     method(_javaPart, resizeMode.has_value() ? JResizeMode::fromCpp(resizeMode.value()) : nullptr);
+  }
+  std::optional<std::string> JHybridNitroImageViewSpec::getRecyclingKey() {
+    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getRecyclingKey");
+    auto __result = method(_javaPart);
+    return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
+  }
+  void JHybridNitroImageViewSpec::setRecyclingKey(const std::optional<std::string>& recyclingKey) {
+    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* recyclingKey */)>("setRecyclingKey");
+    method(_javaPart, recyclingKey.has_value() ? jni::make_jstring(recyclingKey.value()) : nullptr);
   }
 
   // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridNitroImageViewSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JHybridNitroImageViewSpec.hpp
@@ -52,6 +52,8 @@ namespace margelo::nitro::image {
     void setImage(const std::optional<std::variant<std::shared_ptr<margelo::nitro::image::HybridImageSpec>, std::shared_ptr<margelo::nitro::image::HybridImageLoaderSpec>>>& image) override;
     std::optional<ResizeMode> getResizeMode() override;
     void setResizeMode(std::optional<ResizeMode> resizeMode) override;
+    std::optional<std::string> getRecyclingKey() override;
+    void setRecyclingKey(const std::optional<std::string>& recyclingKey) override;
 
   public:
     // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridNitroImageViewStateUpdater.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/views/JHybridNitroImageViewStateUpdater.cpp
@@ -45,6 +45,10 @@ void JHybridNitroImageViewStateUpdater::updateViewProps(jni::alias_ref<jni::JCla
     view->setResizeMode(props.resizeMode.value);
     // TODO: Set isDirty = false
   }
+  if (props.recyclingKey.isDirty) {
+    view->setRecyclingKey(props.recyclingKey.value);
+    // TODO: Set isDirty = false
+  }
 
   // Update hybridRef if it changed
   if (props.hybridRef.isDirty) {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridNitroImageViewSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridNitroImageViewSpec.kt
@@ -49,6 +49,12 @@ abstract class HybridNitroImageViewSpec: HybridView() {
   @set:DoNotStrip
   @set:Keep
   abstract var resizeMode: ResizeMode?
+  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
+  abstract var recyclingKey: String?
 
   // Methods
   

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/NitroImage-Swift-Cxx-Bridge.hpp
@@ -424,5 +424,14 @@ namespace margelo::nitro::image::bridge::swift {
   inline std::optional<ResizeMode> create_std__optional_ResizeMode_(const ResizeMode& value) {
     return std::optional<ResizeMode>(value);
   }
+  
+  // pragma MARK: std::optional<std::string>
+  /**
+   * Specialized version of `std::optional<std::string>`.
+   */
+  using std__optional_std__string_ = std::optional<std::string>;
+  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) {
+    return std::optional<std::string>(value);
+  }
 
 } // namespace margelo::nitro::image::bridge::swift

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridNitroImageViewSpecSwift.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/HybridNitroImageViewSpecSwift.hpp
@@ -25,6 +25,7 @@ namespace margelo::nitro::image { enum class ResizeMode; }
 #include <variant>
 #include <optional>
 #include "ResizeMode.hpp"
+#include <string>
 
 #include "NitroImage-Swift-Cxx-Umbrella.hpp"
 
@@ -76,6 +77,13 @@ namespace margelo::nitro::image {
     }
     inline void setResizeMode(std::optional<ResizeMode> resizeMode) noexcept override {
       _swiftPart.setResizeMode(resizeMode);
+    }
+    inline std::optional<std::string> getRecyclingKey() noexcept override {
+      auto __result = _swiftPart.getRecyclingKey();
+      return __result;
+    }
+    inline void setRecyclingKey(const std::optional<std::string>& recyclingKey) noexcept override {
+      _swiftPart.setRecyclingKey(recyclingKey);
     }
 
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/c++/views/HybridNitroImageViewComponent.mm
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/c++/views/HybridNitroImageViewComponent.mm
@@ -81,6 +81,11 @@ using namespace margelo::nitro::image::views;
     swiftPart.setResizeMode(newViewProps.resizeMode.value);
     newViewProps.resizeMode.isDirty = false;
   }
+  // recyclingKey: optional
+  if (newViewProps.recyclingKey.isDirty) {
+    swiftPart.setRecyclingKey(newViewProps.recyclingKey.value);
+    newViewProps.recyclingKey.isDirty = false;
+  }
 
   swiftPart.afterUpdate();
 

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridNitroImageViewSpec.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridNitroImageViewSpec.swift
@@ -13,6 +13,7 @@ public protocol HybridNitroImageViewSpec_protocol: HybridObject, HybridView {
   // Properties
   var image: Variant__any_HybridImageSpec___any_HybridImageLoaderSpec_? { get set }
   var resizeMode: ResizeMode? { get set }
+  var recyclingKey: String? { get set }
 
   // Methods
   

--- a/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridNitroImageViewSpec_cxx.swift
+++ b/packages/react-native-nitro-image/nitrogen/generated/ios/swift/HybridNitroImageViewSpec_cxx.swift
@@ -178,6 +178,29 @@ open class HybridNitroImageViewSpec_cxx {
       self.__implementation.resizeMode = newValue.value
     }
   }
+  
+  public final var recyclingKey: bridge.std__optional_std__string_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__optional_std__string_ in
+        if let __unwrappedValue = self.__implementation.recyclingKey {
+          return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
+        } else {
+          return .init()
+        }
+      }()
+    }
+    @inline(__always)
+    set {
+      self.__implementation.recyclingKey = { () -> String? in
+        if let __unwrapped = newValue.value {
+          return String(__unwrapped)
+        } else {
+          return nil
+        }
+      }()
+    }
+  }
 
   // Methods
   public final func getView() -> UnsafeMutableRawPointer {

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridNitroImageViewSpec.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridNitroImageViewSpec.cpp
@@ -18,6 +18,8 @@ namespace margelo::nitro::image {
       prototype.registerHybridSetter("image", &HybridNitroImageViewSpec::setImage);
       prototype.registerHybridGetter("resizeMode", &HybridNitroImageViewSpec::getResizeMode);
       prototype.registerHybridSetter("resizeMode", &HybridNitroImageViewSpec::setResizeMode);
+      prototype.registerHybridGetter("recyclingKey", &HybridNitroImageViewSpec::getRecyclingKey);
+      prototype.registerHybridSetter("recyclingKey", &HybridNitroImageViewSpec::setRecyclingKey);
     });
   }
 

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridNitroImageViewSpec.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/HybridNitroImageViewSpec.hpp
@@ -26,6 +26,7 @@ namespace margelo::nitro::image { enum class ResizeMode; }
 #include <variant>
 #include <optional>
 #include "ResizeMode.hpp"
+#include <string>
 
 namespace margelo::nitro::image {
 
@@ -58,6 +59,8 @@ namespace margelo::nitro::image {
       virtual void setImage(const std::optional<std::variant<std::shared_ptr<margelo::nitro::image::HybridImageSpec>, std::shared_ptr<margelo::nitro::image::HybridImageLoaderSpec>>>& image) = 0;
       virtual std::optional<ResizeMode> getResizeMode() = 0;
       virtual void setResizeMode(std::optional<ResizeMode> resizeMode) = 0;
+      virtual std::optional<std::string> getRecyclingKey() = 0;
+      virtual void setRecyclingKey(const std::optional<std::string>& recyclingKey) = 0;
 
     public:
       // Methods

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridNitroImageViewComponent.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridNitroImageViewComponent.cpp
@@ -45,6 +45,16 @@ namespace margelo::nitro::image::views {
         throw std::runtime_error(std::string("NitroImageView.resizeMode: ") + exc.what());
       }
     }()),
+    recyclingKey([&]() -> CachedProp<std::optional<std::string>> {
+      try {
+        const react::RawValue* rawValue = rawProps.at("recyclingKey", nullptr, nullptr);
+        if (rawValue == nullptr) return sourceProps.recyclingKey;
+        const auto& [runtime, value] = (std::pair<jsi::Runtime*, jsi::Value>)*rawValue;
+        return CachedProp<std::optional<std::string>>::fromRawValue(*runtime, value, sourceProps.recyclingKey);
+      } catch (const std::exception& exc) {
+        throw std::runtime_error(std::string("NitroImageView.recyclingKey: ") + exc.what());
+      }
+    }()),
     hybridRef([&]() -> CachedProp<std::optional<std::function<void(const std::shared_ptr<margelo::nitro::image::HybridNitroImageViewSpec>& /* ref */)>>> {
       try {
         const react::RawValue* rawValue = rawProps.at("hybridRef", nullptr, nullptr);
@@ -60,12 +70,14 @@ namespace margelo::nitro::image::views {
     react::ViewProps(),
     image(other.image),
     resizeMode(other.resizeMode),
+    recyclingKey(other.recyclingKey),
     hybridRef(other.hybridRef) { }
 
   bool HybridNitroImageViewProps::filterObjectKeys(const std::string& propName) {
     switch (hashString(propName)) {
       case hashString("image"): return true;
       case hashString("resizeMode"): return true;
+      case hashString("recyclingKey"): return true;
       case hashString("hybridRef"): return true;
       default: return false;
     }

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridNitroImageViewComponent.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridNitroImageViewComponent.hpp
@@ -24,6 +24,8 @@
 #include <optional>
 #include "ResizeMode.hpp"
 #include <optional>
+#include <string>
+#include <optional>
 #include <memory>
 #include "HybridNitroImageViewSpec.hpp"
 #include <functional>
@@ -52,6 +54,7 @@ namespace margelo::nitro::image::views {
   public:
     CachedProp<std::optional<std::variant<std::shared_ptr<margelo::nitro::image::HybridImageSpec>, std::shared_ptr<margelo::nitro::image::HybridImageLoaderSpec>>>> image;
     CachedProp<std::optional<ResizeMode>> resizeMode;
+    CachedProp<std::optional<std::string>> recyclingKey;
     CachedProp<std::optional<std::function<void(const std::shared_ptr<margelo::nitro::image::HybridNitroImageViewSpec>& /* ref */)>>> hybridRef;
 
   private:

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/json/NitroImageViewConfig.json
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/json/NitroImageViewConfig.json
@@ -6,6 +6,7 @@
   "validAttributes": {
     "image": true,
     "resizeMode": true,
+    "recyclingKey": true,
     "hybridRef": true
   }
 }

--- a/packages/react-native-nitro-image/src/specs/ImageView.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/ImageView.nitro.ts
@@ -38,6 +38,23 @@ export interface NativeNitroImageViewProps extends HybridViewProps {
      * @default 'cover'
      */
     resizeMode?: ResizeMode;
+    /**
+     * A key that uniquely identifies an Image that should be displayed.
+     *
+     * If the {@linkcode recyclingKey} changes, the displayed {@linkcode Image}
+     * will be cleared to display _nothing_, until the next {@linkcode Image}
+     * has been loaded.
+     *
+     * It is recommended to set this to the {@linkcode Image}'s URL in
+     * large lists to prevent the recycled views from displaying
+     * stale {@linkcode Image} instances.
+     * @default undefined
+     * @example
+     * ```tsx
+     * <NitroImage recyclingKey={url} />
+     * ```
+     */
+    recyclingKey?: string
 }
 
 export interface NativeNitroImageViewMethods extends HybridViewMethods {


### PR DESCRIPTION
Useful when rendering a lot of Images in a large List.

If not used, newly recycled Images will contain old image sources, which looks buggy.
Now, they will be blank instead of showing old images.