### PR TITLE
fix: Add `__source` to `Image`/`ImageLoader` so React diffs properly

### DIFF
--- a/example/src/EmptyTab.tsx
+++ b/example/src/EmptyTab.tsx
@@ -1,10 +1,15 @@
-import { StyleSheet, Text, View } from "react-native";
+import { useState } from "react";
+import { StyleSheet, Text, TextInput, View } from "react-native";
+import { NitroImage } from "react-native-nitro-image";
 
 export function EmptyTab() {
+    const [value, setValue] = useState('https://picsum.photos/seed/123/400')
+
     return (
         <View style={styles.container}>
             <Text style={styles.text}>
-                Select a Tab to display the Images List.
+                <TextInput placeholder="Image URL" value={value} onChangeText={setValue} style={styles.textInput} />
+                <NitroImage image={{ url: value }} style={styles.image} />
             </Text>
         </View>
     );
@@ -20,4 +25,14 @@ const styles = StyleSheet.create({
         fontSize: 18,
         fontWeight: "500",
     },
+    textInput: {
+        height: 50,
+        width: '100%'
+    },
+    image: {
+        width: 400,
+        height: 400,
+        borderColor: 'grey',
+        borderWidth: StyleSheet.hairlineWidth
+    }
 });

--- a/packages/react-native-nitro-image/src/useImageLoader.ts
+++ b/packages/react-native-nitro-image/src/useImageLoader.ts
@@ -8,19 +8,16 @@ export function useImageLoader(
     source: AsyncImageSource,
 ): Image | ImageLoader | undefined {
     // biome-ignore lint: The dependencies array is a bit hacky.
-    return useMemo<Image | ImageLoader | undefined>(
-        () => {
-            // 1. Create the Image/ImageLoader instance
-            const loader = createImageLoader(source)
-            // 2. Add `__source` as a property on the JS side so React diffs properly
-            Object.defineProperty(loader, '__source', {
-                enumerable: true,
-                configurable: true,
-                value: source
-            })
-            // 3. Return it
-            return loader
-        },
-        [isHybridObject(source) ? source : JSON.stringify(source)],
-    );
+    return useMemo<Image | ImageLoader | undefined>(() => {
+        // 1. Create the Image/ImageLoader instance
+        const loader = createImageLoader(source);
+        // 2. Add `__source` as a property on the JS side so React diffs properly
+        Object.defineProperty(loader, "__source", {
+            enumerable: true,
+            configurable: true,
+            value: source,
+        });
+        // 3. Return it
+        return loader;
+    }, [isHybridObject(source) ? source : JSON.stringify(source)]);
 }

--- a/packages/react-native-nitro-image/src/useImageLoader.ts
+++ b/packages/react-native-nitro-image/src/useImageLoader.ts
@@ -9,7 +9,18 @@ export function useImageLoader(
 ): Image | ImageLoader | undefined {
     // biome-ignore lint: The dependencies array is a bit hacky.
     return useMemo<Image | ImageLoader | undefined>(
-        () => createImageLoader(source),
+        () => {
+            // 1. Create the Image/ImageLoader instance
+            const loader = createImageLoader(source)
+            // 2. Add `__source` as a property on the JS side so React diffs properly
+            Object.defineProperty(loader, '__source', {
+                enumerable: true,
+                configurable: true,
+                value: source
+            })
+            // 3. Return it
+            return loader
+        },
         [isHybridObject(source) ? source : JSON.stringify(source)],
     );
 }

--- a/packages/react-native-nitro-web-image/ios/HybridWebImageLoader.swift
+++ b/packages/react-native-nitro-web-image/ios/HybridWebImageLoader.swift
@@ -36,7 +36,7 @@ class HybridWebImageLoader: HybridImageLoaderSpec {
 
     let webImageOptions = options?.toSDWebImageOptions() ?? []
     view.imageView.sd_setImage(with: url,
-                               placeholderImage: nil,
+                               placeholderImage: view.imageView.image,
                                options: webImageOptions,
                                context: nil)
   }


### PR DESCRIPTION
React didn't update the `image` property if it "looked" the same. (Even tho they aren't the same).

We fix this by adding `__source` to the actual image on the JS side.

- Fixes #38