### PR TITLE
fix: export NitroImageProps type

### DIFF
--- a/packages/react-native-nitro-image/src/index.ts
+++ b/packages/react-native-nitro-image/src/index.ts
@@ -3,7 +3,7 @@ export * from "./Images";
 export * from "./ImageUtils";
 export * from "./loadImage";
 export { NativeNitroImage } from "./NativeNitroImage";
-export { NitroImage } from "./NitroImage";
+export { NitroImage, type NitroImageProps } from "./NitroImage";
 export type { Image } from "./specs/Image.nitro";
 export type { ImageLoader } from "./specs/ImageLoader.nitro";
 


### PR DESCRIPTION
Hi 👋 hope PRs are ok for this project. When making a custom image component, I noticed that the `NitroImageProps` type isn't exported from the package, and currently you have to import it from the lib folder: 

```
import { NitroImageProps } from 'react-native-nitro-image/lib/typescript/NitroImage';
```

This PR just exports `NativeImageProps` so that consumers can import it from the root, i.e. 

```
import { NitroImageProps } from 'react-native-nitro-image' 
```