### PR TITLE
fix: use direct byte buffer

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImage.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImage.kt
@@ -42,8 +42,9 @@ class HybridImage: HybridImageSpec {
             bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, false)
         }
 
-        val buffer = ByteBuffer.allocate(bitmap.byteCount)
+        val buffer = ByteBuffer.allocateDirect(bitmap.byteCount)
         bitmap.copyPixelsToBuffer(buffer)
+        buffer.rewind()
         return buffer
     }
 


### PR DESCRIPTION
## Summary
Return direct buffer in `toByteBuffer` as [`ArrayBuffer` require ByteBuffer to be direct ](https://github.com/mrousavy/nitro/blob/64c802345f7d6d930530c96f8a9965925fc131e8/packages/react-native-nitro-modules/android/src/main/java/com/margelo/nitro/core/ArrayBuffer.kt#L97-L103)