### PR TITLE
feat: add gif support to android

### DIFF
--- a/packages/react-native-nitro-web-image/android/build.gradle
+++ b/packages/react-native-nitro-web-image/android/build.gradle
@@ -141,5 +141,6 @@ dependencies {
   // Coil
   implementation("io.coil-kt.coil3:coil:3.3.0")
   implementation("io.coil-kt.coil3:coil-network-okhttp:3.3.0")
+  implementation("io.coil-kt.coil3:coil-gif:3.3.0")
 }
 


### PR DESCRIPTION
This PR adds GIF support to Android. I didn't test if IOS already supports it or not
but I read that [SDWebImage](https://github.com/SDWebImage/SDWebImage) supports GIF.
If it's not supported, I can extend this PR to include IOS.