### PR TITLE
fix: Fix `Couldn't find class HybridImageLoaderFactory` crash in release

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageLoaderFactory.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageLoaderFactory.kt
@@ -1,8 +1,12 @@
 package com.margelo.nitro.image
 
+import androidx.annotation.Keep
+import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.ArrayBuffer
 import com.margelo.nitro.core.Promise
 
+@Keep
+@DoNotStrip
 class HybridImageLoaderFactory: HybridImageLoaderFactorySpec() {
     private val factory = HybridImageFactory()
 


### PR DESCRIPTION
- Fixes https://github.com/mrousavy/react-native-nitro-image/issues/66