### PR TITLE
feat: Add `dispose()` implementation for Android

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImage.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImage.kt
@@ -31,6 +31,10 @@ class HybridImage: HybridImageSpec {
         this.bitmap = bitmap
     }
 
+    override fun dispose() {
+        bitmap.recycle()
+    }
+
     override fun toRawPixelData(allowGpu: Boolean?): RawPixelData {
         val allowGpu = allowGpu ?: false
         if (allowGpu && bitmap.isGPU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {


### PR DESCRIPTION
When you call `dispose()` on an `Image` on Android, it will now call `Bitmap.recycle()`. See [Managing Bitmap Memory](https://developer.android.com/topic/performance/graphics/manage-memory)