### PR TITLE
fix: Image not loading when file:// in URL

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageFactory.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageFactory.kt
@@ -89,7 +89,8 @@ class HybridImageFactory: HybridImageFactorySpec() {
     }
 
     override fun loadFromFile(filePath: String): HybridImageSpec {
-        val bitmap = BitmapFactory.decodeFile(filePath)
+        val cleanPath = filePath.removePrefix("file://")
+        val bitmap = BitmapFactory.decodeFile(cleanPath)
         if (bitmap == null) {
             throw Error("Failed to load Image from file! (Path: $filePath)")
         }


### PR DESCRIPTION
So when OTA Updates the bundle (For Example Nitro OTA or hot updater).  
It fails with below error even when file exist 
```
E  Unable to decode file: java.io.FileNotFoundException: file:///data/user/0/com.myApp/files/ota_unzipped_1764700762170/App-Bundles/drawable-mdpi/app_assets_images_login.png: open failed: ENOENT (No such file or directory)
```

RCA :-
decodeFile uses  FileInputStream(pathName) which accepts urls (without `file://` prefix) .

