### PR TITLE
fix/memory leaks for android especially during recycler view usage

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageFactory.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageFactory.kt
@@ -14,15 +14,21 @@ import com.margelo.nitro.core.Promise
 import com.margelo.nitro.image.extensions.bitmapFromRawPixelData
 import com.margelo.nitro.image.extensions.toBitmapColor
 import java.nio.ByteBuffer
+import kotlin.math.max
 
 @DoNotStrip
 @Keep
-class HybridImageFactory: HybridImageFactorySpec() {
-    override fun createBlankImage(width: Double, height: Double, enableAlpha: Boolean, fill: Color?): HybridImageSpec {
-        // 1. Create Bitmap config (either ARGB or RGB without alpha)
+class HybridImageFactory : HybridImageFactorySpec() {
+    override fun createBlankImage(
+        width: Double,
+        height: Double,
+        enableAlpha: Boolean,
+        fill: Color?
+    ): HybridImageSpec {
         val config = if (enableAlpha) Bitmap.Config.ARGB_8888 else Bitmap.Config.RGB_565
         // 2. Create the new Bitmap
         val bitmap = createBitmap(width.toInt(), height.toInt(), config)
+
         if (fill != null) {
             // 3. If we have a background fill, draw it!
             val color = fill.toBitmapColor()
@@ -31,30 +37,39 @@ class HybridImageFactory: HybridImageFactorySpec() {
         // 4. Wrap it in a HybridImage and return it
         return HybridImage(bitmap)
     }
-    override fun createBlankImageAsync(width: Double, height: Double, enableAlpha: Boolean, fill: Color?): Promise<HybridImageSpec> {
-        return Promise.async { createBlankImage(width, height, enableAlpha, fill) }
+
+    override fun createBlankImageAsync(
+        width: Double,
+        height: Double,
+        enableAlpha: Boolean,
+        fill: Color?
+    ): Promise<HybridImageSpec> {
+        return Promise.async {
+            createBlankImage(width, height, enableAlpha, fill)
+        }
     }
 
     @SuppressLint("DiscouragedApi")
     override fun loadFromResources(name: String): HybridImageSpec {
         val context = NitroModules.applicationContext ?: throw Error("No context!")
-        // Look up ID via it's name
-        val rawResourceId: Int = context.resources
-            .getIdentifier(name, "drawable", context.packageName)
+
+        val rawResourceId = context.resources.getIdentifier(name, "drawable", context.packageName)
+
         if (rawResourceId == 0) {
-            // It's bundled into the Android resources/assets
             context.assets.open(name).use { stream ->
                 val bitmap = BitmapFactory.decodeStream(stream)
-                return HybridImage(bitmap)
-            }
-        } else {
-            // For assets bundled with 'require' instead of linked, they are bundled into `res/raw` in release mode
-            context.resources.openRawResource(rawResourceId).use { stream ->
-                val bitmap = BitmapFactory.decodeStream(stream)
+                    ?: throw Error("Failed to decode Image from assets! (Name: $name)")
                 return HybridImage(bitmap)
             }
         }
+
+        context.resources.openRawResource(rawResourceId).use { stream ->
+            val bitmap = BitmapFactory.decodeStream(stream)
+                ?: throw Error("Failed to decode Image from resources! (Name: $name)")
+            return HybridImage(bitmap)
+        }
     }
+
     override fun loadFromResourcesAsync(name: String): Promise<HybridImageSpec> {
         return Promise.async { loadFromResources(name) }
     }
@@ -64,11 +79,13 @@ class HybridImageFactory: HybridImageFactorySpec() {
     }
 
     override fun loadFromRawPixelData(data: RawPixelData, allowGpu: Boolean?): HybridImageSpec {
-        val allowGpu = allowGpu ?: false
-        val bitmap = bitmapFromRawPixelData(data, allowGpu)
+        val resolvedAllowGpu = allowGpu ?: false
+        val bitmap = bitmapFromRawPixelData(data, resolvedAllowGpu)
         return HybridImage(bitmap)
     }
-    override fun loadFromRawPixelDataAsync(data: RawPixelData, allowGpu: Boolean?): Promise<HybridImageSpec> {
+
+    override fun loadFromRawPixelDataAsync(data: RawPixelData, allowGpu: Boolean?): Promise<HybridI
+mageSpec> {
         val bufferCopy = data.buffer.asOwning()
         val dataCopy = RawPixelData(bufferCopy, data.width, data.height, data.pixelFormat)
         return Promise.async { loadFromRawPixelData(dataCopy, allowGpu) }
@@ -76,31 +93,134 @@ class HybridImageFactory: HybridImageFactorySpec() {
 
     private fun loadFromEncodedBytes(bytes: ByteArray): HybridImageSpec {
         val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-        if (bitmap == null) {
-            throw Error("Failed to decode EncodedImageData to an Image! (Bytes: ${bytes.size})")
-        }
+            ?: throw Error("Failed to decode EncodedImageData to an Image! (Bytes: ${bytes.size})")
+
         return HybridImage(bitmap)
     }
+
     override fun loadFromEncodedImageData(data: EncodedImageData): HybridImageSpec {
         val bytes = data.buffer.toByteArray()
         return loadFromEncodedBytes(bytes)
     }
+
     override fun loadFromEncodedImageDataAsync(data: EncodedImageData): Promise<HybridImageSpec> {
+        // We need to copy before jumping Threads
         val bytes = data.buffer.toByteArray()
         return Promise.async { loadFromEncodedBytes(bytes) }
     }
 
     override fun loadFromFile(filePath: String): HybridImageSpec {
-        val cleanPath = filePath.removePrefix("file://")
-        val bitmap = BitmapFactory.decodeFile(cleanPath)
-        if (bitmap == null) {
-            throw Error("Failed to load Image from file! (Path: $filePath)")
-        }
+        val bitmap = decodeBitmapFromFile(filePath, null, null)
+        return HybridImage(bitmap)
+    }
+
+    fun loadFromFile(
+        filePath: String,
+        targetWidth: Int?,
+        targetHeight: Int?
+    ): HybridImageSpec {
+        val bitmap = decodeBitmapFromFile(filePath, targetWidth, targetHeight)
         return HybridImage(bitmap)
     }
 
     override fun loadFromFileAsync(filePath: String): Promise<HybridImageSpec> {
-        return Promise.async { loadFromFile(filePath) }
+        return loadFromFileAsync(filePath, null, null)
+    }
+
+    fun loadFromFileAsync(
+        filePath: String,
+        targetWidth: Int?,
+        targetHeight: Int?
+    ): Promise<HybridImageSpec> {
+        return Promise.async {
+            loadFromFile(filePath, targetWidth, targetHeight)
+        }
+    }
+
+    fun decodeBitmapFromFile(
+        filePath: String,
+        targetWidth: Int?,
+        targetHeight: Int?
+    ): Bitmap {
+        val cleanPath = filePath.removePrefix("file://")
+
+        return decodeFile(cleanPath, targetWidth, targetHeight)
+            ?: throw Error("Failed to load Image from file! (Path: $filePath)")
+    }
+
+    private fun decodeFile(
+        cleanPath: String,
+        targetWidth: Int?,
+        targetHeight: Int?
+    ): Bitmap? {
+        val resolvedTargetWidth = targetWidth ?: 0
+        val resolvedTargetHeight = targetHeight ?: 0
+
+        if (resolvedTargetWidth <= 0 || resolvedTargetHeight <= 0) {
+            return BitmapFactory.decodeFile(cleanPath)
+        }
+
+        val boundsOptions = BitmapFactory.Options().apply {
+            inJustDecodeBounds = true
+        }
+
+        BitmapFactory.decodeFile(cleanPath, boundsOptions)
+
+        if (boundsOptions.outWidth <= 0 || boundsOptions.outHeight <= 0) {
+            return BitmapFactory.decodeFile(cleanPath)
+        }
+
+        val decodeOptions = BitmapFactory.Options().apply {
+            inJustDecodeBounds = false
+            inPreferredConfig = Bitmap.Config.ARGB_8888
+            inSampleSize = calculateInSampleSize(
+                sourceWidth = boundsOptions.outWidth,
+                sourceHeight = boundsOptions.outHeight,
+                targetWidth = resolvedTargetWidth,
+                targetHeight = resolvedTargetHeight
+            )
+        }
+
+        return BitmapFactory.decodeFile(cleanPath, decodeOptions)
+    }
+
+    private fun calculateInSampleSize(
+        sourceWidth: Int,
+        sourceHeight: Int,
+        targetWidth: Int,
+        targetHeight: Int
+    ): Int {
+        if (targetWidth <= 0 || targetHeight <= 0) {
+            return 1
+        }
+
+        var inSampleSize = 1
+
+        while (
+            sourceWidth / (inSampleSize * 2) >= targetWidth ||
+            sourceHeight / (inSampleSize * 2) >= targetHeight
+        ) {
+            inSampleSize *= 2
+        }
+
+        return max(1, inSampleSize)
+    }
+
+    private fun logDecoded(
+        cleanPath: String,
+        bitmap: Bitmap?,
+        targetWidth: Int,
+        targetHeight: Int
+    ) {
+        if (bitmap == null) {
+            return
+        }
+
+        Log.d(
+            TAG,
+            "decoded file=$cleanPath width=${bitmap.width} height=${bitmap.height} " +
+                "bytes=${bitmap.allocationByteCount} target=${targetWidth}x${targetHeight}"
+        )
     }
 
     private fun loadFromThumbHash(thumbHashBytes: ByteArray): HybridImage {
@@ -109,6 +229,7 @@ class HybridImageFactory: HybridImageFactorySpec() {
         val bitmap = createBitmap(rgba.width, rgba.height, Bitmap.Config.ARGB_8888)
         val buffer = ByteBuffer.wrap(rgba.rgba)
         bitmap.copyPixelsFromBuffer(buffer)
+
         return HybridImage(bitmap)
     }
 
@@ -118,8 +239,10 @@ class HybridImageFactory: HybridImageFactorySpec() {
     }
 
     override fun loadFromThumbHashAsync(thumbhash: ArrayBuffer): Promise<HybridImageSpec> {
-        // We need to copy before jumping Threads
         val bytes = thumbhash.toByteArray()
-        return Promise.async { loadFromThumbHash(bytes) }
+
+        return Promise.async {
+            loadFromThumbHash(bytes)
+        }
     }
 }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageFactory.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageFactory.kt
@@ -84,8 +84,7 @@ class HybridImageFactory : HybridImageFactorySpec() {
         return HybridImage(bitmap)
     }
 
-    override fun loadFromRawPixelDataAsync(data: RawPixelData, allowGpu: Boolean?): Promise<HybridI
-mageSpec> {
+    override fun loadFromRawPixelDataAsync(data: RawPixelData, allowGpu: Boolean?): Promise<HybridImageSpec> {
         val bufferCopy = data.buffer.asOwning()
         val dataCopy = RawPixelData(bufferCopy, data.width, data.height, data.pixelFormat)
         return Promise.async { loadFromRawPixelData(dataCopy, allowGpu) }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageFactory.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageFactory.kt
@@ -206,23 +206,6 @@ mageSpec> {
         return max(1, inSampleSize)
     }
 
-    private fun logDecoded(
-        cleanPath: String,
-        bitmap: Bitmap?,
-        targetWidth: Int,
-        targetHeight: Int
-    ) {
-        if (bitmap == null) {
-            return
-        }
-
-        Log.d(
-            TAG,
-            "decoded file=$cleanPath width=${bitmap.width} height=${bitmap.height} " +
-                "bytes=${bitmap.allocationByteCount} target=${targetWidth}x${targetHeight}"
-        )
-    }
-
     private fun loadFromThumbHash(thumbHashBytes: ByteArray): HybridImage {
         val rgba = ThumbHash.thumbHashToRGBA(thumbHashBytes)
 

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageLoader.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageLoader.kt
@@ -1,51 +1,581 @@
 package com.margelo.nitro.image
 
+import android.graphics.Bitmap
+import android.util.Log
+import android.util.LruCache
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.Promise
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import java.util.WeakHashMap
+import kotlin.math.max
+
+internal object RenderBitmapMemoryCache {
+    private const val TAG = "RenderBitmapMemoryCache"
+
+    // Keep this conservative first. Raise later once behavior is stable.
+    private const val MAX_CACHE_KB = 96 * 1024
+
+    private val lock = Any()
+    private val activeCounts = HashMap<String, Int>()
+    private val pendingEvictions = HashMap<String, MutableList<Bitmap>>()
+
+    private val cache = object : LruCache<String, Bitmap>(MAX_CACHE_KB) {
+        override fun sizeOf(key: String, value: Bitmap): Int {
+            return max(1, value.allocationByteCount / 1024)
+        }
+
+        override fun entryRemoved(
+            evicted: Boolean,
+            key: String,
+            oldValue: Bitmap,
+            newValue: Bitmap?
+        ) {
+            if (oldValue === newValue) {
+                return
+            }
+
+            recycleOrDefer(key, oldValue, "cache eviction")
+        }
+    }
+
+    fun getAndAcquire(key: String): Bitmap? {
+        synchronized(lock) {
+            val bitmap = cache.get(key)
+
+            if (bitmap == null || bitmap.isRecycled) {
+                if (bitmap != null) {
+                    cache.remove(key)
+                }
+                return null
+            }
+
+            activeCounts[key] = (activeCounts[key] ?: 0) + 1
+
+            
+            return bitmap
+        }
+    }
+
+    fun putAndAcquire(key: String, bitmap: Bitmap): Bitmap {
+        synchronized(lock) {
+            val existing = cache.get(key)
+
+            if (existing != null && !existing.isRecycled) {
+                activeCounts[key] = (activeCounts[key] ?: 0) + 1
+
+                if (existing !== bitmap) {
+                    recycleBitmap(bitmap, "duplicate decoded bitmap discarded")
+                }
+
+                
+                return existing
+            }
+
+            activeCounts[key] = (activeCounts[key] ?: 0) + 1
+            cache.put(key, bitmap)
+
+            
+            return bitmap
+        }
+    }
+
+    fun release(key: String) {
+        val evictedToRecycle = mutableListOf<Bitmap>()
+
+        synchronized(lock) {
+            val current = activeCounts[key] ?: return
+            val next = current - 1
+
+            if (next > 0) {
+                activeCounts[key] = next
+                                return
+            }
+
+            activeCounts.remove(key)
+
+            pendingEvictions.remove(key)?.let { pending ->
+                evictedToRecycle.addAll(pending)
+            }
+
+                    }
+
+        evictedToRecycle.forEach { bitmap ->
+            recycleBitmap(bitmap, "deferred cache eviction release")
+        }
+    }
+
+    private fun recycleOrDefer(key: String, bitmap: Bitmap, reason: String) {
+        synchronized(lock) {
+            val activeCount = activeCounts[key] ?: 0
+
+            if (activeCount > 0) {
+                val pending = pendingEvictions[key] ?: mutableListOf<Bitmap>().also {
+                    pendingEvictions[key] = it
+                }
+                pending.add(bitmap)
+
+                
+                return
+            }
+        }
+
+        recycleBitmap(bitmap, reason)
+    }
+
+    private fun recycleBitmap(bitmap: Bitmap, reason: String) {
+        try {
+            if (!bitmap.isRecycled) {
+                bitmap.recycle()
+            }
+        } catch (e: Throwable) {
+            Log.e(TAG, "Failed to recycle cached Bitmap! reason=$reason", e)
+        }
+    }
+}
+
+internal object RenderBitmapDecodeCoordinator {
+    private const val TAG = "RenderBitmapDecodeCoordinator"
+
+    private val lock = Any()
+    private val inFlight = HashMap<String, CompletableDeferred<Bitmap>>()
+
+    fun getOrCreate(key: String): Pair<CompletableDeferred<Bitmap>, Boolean> {
+        synchronized(lock) {
+            val existing = inFlight[key]
+            if (existing != null) {
+                                return existing to false
+            }
+
+            val deferred = CompletableDeferred<Bitmap>()
+            inFlight[key] = deferred
+                        return deferred to true
+        }
+    }
+
+    fun complete(key: String, bitmap: Bitmap) {
+        val deferred = synchronized(lock) {
+            inFlight.remove(key)
+        }
+
+        deferred?.complete(bitmap)
+    }
+
+    fun fail(key: String, throwable: Throwable) {
+        val deferred = synchronized(lock) {
+            inFlight.remove(key)
+        }
+
+        deferred?.completeExceptionally(throwable)
+    }
+}
 
 @Keep
 @DoNotStrip
 class HybridImageLoader(
-    private val loadImageFunc: () -> Promise<HybridImageSpec>,
-    private val allowCaching: Boolean = true
-): HybridImageLoaderSpec() {
+    private val loadImageFunc: (targetWidth: Int?, targetHeight: Int?) -> Promise<HybridImageSpec>,
+    private val allowCaching: Boolean = true,
+    private val renderCacheKey: String? = null,
+    private val renderBitmapFunc: ((targetWidth: Int?, targetHeight: Int?) -> Bitmap)? = null
+) : HybridImageLoaderSpec() {
+    companion object {
+        private const val TAG = "HybridImageLoader"
+    }
+
+    private data class CacheKey(
+        val targetWidth: Int?,
+        val targetHeight: Int?
+    )
+
     private var cachedResult: HybridImageSpec? = null
-    private val uiScope = CoroutineScope(Dispatchers.Main.immediate)
+    private var cachedKey: CacheKey? = null
+    private var isDisposed = false
+
+    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val uiScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    private val pendingJobs = WeakHashMap<HybridImageView, MutableList<Job>>()
+    private val requestGenerations = WeakHashMap<HybridImageView, Int>()
+    private val displayedHybridImages = WeakHashMap<HybridImageView, HybridImage>()
+
+    override fun dispose() {
+        isDisposed = true
+
+        pendingJobs.values.forEach { jobs ->
+            jobs.forEach { job -> job.cancel() }
+        }
+
+        pendingJobs.clear()
+        requestGenerations.clear()
+
+        releaseAllDisplayedHybridImages()
+
+        cachedResult = null
+        cachedKey = null
+
+        ioScope.cancel()
+        uiScope.cancel()
+    }
 
     override fun loadImage(): Promise<HybridImageSpec> {
-        if (allowCaching) {
-            // We can cache the last loaded image in state, so future requests receive it instantly
-            cachedResult?.let { cachedResult ->
-                return Promise.resolved(cachedResult)
-            }
-            return loadImageFunc()
-                .then { image ->
-                    this.cachedResult = image
-                }
-        } else {
-            return loadImageFunc()
+        return loadImage(null, null)
+    }
+
+    private fun loadImage(targetWidth: Int?, targetHeight: Int?): Promise<HybridImageSpec> {
+        if (isDisposed) {
+            throw Error("Cannot load image from a disposed HybridImageLoader!")
         }
+
+        val key = CacheKey(targetWidth, targetHeight)
+
+        if (allowCaching) {
+            val result = cachedResult
+            if (result != null && cachedKey == key) {
+                return Promise.resolved(result)
+            }
+
+            return loadImageFunc(targetWidth, targetHeight)
+                .then { image ->
+                    if (!isDisposed) {
+                        cachedResult = image
+                        cachedKey = key
+                    }
+                }
+        }
+
+        return loadImageFunc(targetWidth, targetHeight)
     }
 
     override fun requestImage(forView: HybridNitroImageViewSpec) {
         val view = forView as? HybridImageView ?: return
 
-        loadImage().then { maybeImage ->
-            val image = maybeImage as? HybridImage ?: return@then
-            uiScope.launch {
-                view.imageView.setImageBitmap(image.bitmap)
-            }
+        
+        val renderFunc = renderBitmapFunc
+        if (renderFunc != null) {
+            requestRenderBitmap(view, renderFunc)
+            return
         }
+
+        requestHybridImage(view)
     }
 
     override fun dropImage(forView: HybridNitroImageViewSpec) {
         val view = forView as? HybridImageView ?: return
+
+        
+        invalidateRequest(view)
+
         uiScope.launch {
-            view.imageView.setImageDrawable(null)
+            val clearedRenderBitmap = view.clearRenderBitmapForOwner(
+                this@HybridImageLoader,
+                "dropImage"
+            )
+            val clearedHybridImage = releaseDisplayedHybridImage(view)
+
+            if (clearedHybridImage && !clearedRenderBitmap) {
+                view.imageView.setImageDrawable(null)
+            }
+
+            if (!clearedRenderBitmap &&
+                !clearedHybridImage &&
+                view.isCurrentImageLoader(this@HybridImageLoader)
+            ) {
+                view.imageView.setImageDrawable(null)
+            }
+
+            removeCompletedJobs(view)
+        }
+
+        if (!allowCaching) {
+            cachedResult = null
+            cachedKey = null
+        }
+    }
+
+    private fun requestRenderBitmap(
+        view: HybridImageView,
+        renderFunc: (targetWidth: Int?, targetHeight: Int?) -> Bitmap
+    ) {
+        val generation = nextGeneration(view)
+        val targetWidth = view.targetImageWidth()
+        val targetHeight = view.targetImageHeight()
+        val cacheKey = buildRenderCacheKey(targetWidth, targetHeight)
+
+        if (cacheKey != null) {
+            val cachedBitmap = RenderBitmapMemoryCache.getAndAcquire(cacheKey)
+            if (cachedBitmap != null) {
+                uiScope.launch {
+                    if (
+                        isDisposed ||
+                        !isCurrentRequest(view, generation) ||
+                        !view.isCurrentImageLoader(this@HybridImageLoader)
+                    ) {
+                        RenderBitmapMemoryCache.release(cacheKey)
+                        removeCompletedJobs(view)
+                        return@launch
+                    }
+
+                    releaseDisplayedHybridImage(view)
+                    view.setRenderBitmap(
+                        owner = this@HybridImageLoader,
+                        bitmap = cachedBitmap,
+                        cacheKey = cacheKey
+                    )
+
+                    removeCompletedJobs(view)
+                }
+                return
+            }
+        }
+
+        val job = ioScope.launch {
+            var decodedBitmap: Bitmap? = null
+            var acquiredCacheKey: String? = null
+
+            try {
+                val loadedBitmap = if (cacheKey != null) {
+                    acquiredCacheKey = cacheKey
+                    getOrDecodeCachedBitmap(
+                        cacheKey = cacheKey,
+                        targetWidth = targetWidth,
+                        targetHeight = targetHeight,
+                        renderFunc = renderFunc
+                    )
+                } else {
+                    renderFunc(targetWidth, targetHeight)
+                }
+
+                decodedBitmap = loadedBitmap
+
+                uiScope.launch {
+                    val bitmapToAssign = decodedBitmap
+                    decodedBitmap = null
+
+                    if (bitmapToAssign == null) {
+                        removeCompletedJobs(view)
+                        return@launch
+                    }
+
+                    try {
+                        if (
+                            isDisposed ||
+                            !isCurrentRequest(view, generation) ||
+                            !view.isCurrentImageLoader(this@HybridImageLoader)
+                        ) {
+                            releaseOrRecycleBitmap(
+                                bitmap = bitmapToAssign,
+                                cacheKey = acquiredCacheKey,
+                                reason = "stale render decode"
+                            )
+                            removeCompletedJobs(view)
+                            return@launch
+                        }
+
+                        releaseDisplayedHybridImage(view)
+
+                        view.setRenderBitmap(
+                            owner = this@HybridImageLoader,
+                            bitmap = bitmapToAssign,
+                            cacheKey = acquiredCacheKey
+                        )
+
+                        removeCompletedJobs(view)
+                    } catch (e: Throwable) {
+                        releaseOrRecycleBitmap(
+                            bitmap = bitmapToAssign,
+                            cacheKey = acquiredCacheKey,
+                            reason = "failed render assignment"
+                        )
+
+                        Log.e(TAG, "Failed to assign render Bitmap!", e)
+                        removeCompletedJobs(view)
+                    }
+                }
+            } catch (e: Throwable) {
+                val bitmapToRelease = decodedBitmap
+                decodedBitmap = null
+
+                if (bitmapToRelease != null) {
+                    releaseOrRecycleBitmap(
+                        bitmap = bitmapToRelease,
+                        cacheKey = acquiredCacheKey,
+                        reason = "failed render decode"
+                    )
+                }
+
+                Log.e(TAG, "Failed to request render Bitmap!", e)
+                removeCompletedJobs(view)
+            }
+        }
+
+        addPendingJob(view, job)
+    }
+
+    private suspend fun getOrDecodeCachedBitmap(
+        cacheKey: String,
+        targetWidth: Int,
+        targetHeight: Int,
+        renderFunc: (targetWidth: Int?, targetHeight: Int?) -> Bitmap
+    ): Bitmap {
+        RenderBitmapMemoryCache.getAndAcquire(cacheKey)?.let { cached ->
+            return cached
+        }
+
+        val (deferred, isOwner) = RenderBitmapDecodeCoordinator.getOrCreate(cacheKey)
+
+        if (isOwner) {
+            try {
+                val decoded = renderFunc(targetWidth, targetHeight)
+                val cached = RenderBitmapMemoryCache.putAndAcquire(cacheKey, decoded)
+                RenderBitmapDecodeCoordinator.complete(cacheKey, cached)
+                return cached
+            } catch (e: Throwable) {
+                RenderBitmapDecodeCoordinator.fail(cacheKey, e)
+                throw e
+            }
+        }
+
+        deferred.await()
+
+        RenderBitmapMemoryCache.getAndAcquire(cacheKey)?.let { cached ->
+            return cached
+        }
+
+        val decoded = renderFunc(targetWidth, targetHeight)
+        return RenderBitmapMemoryCache.putAndAcquire(cacheKey, decoded)
+    }
+
+    private fun requestHybridImage(view: HybridImageView) {
+        val generation = nextGeneration(view)
+        val targetWidth = view.targetImageWidth()
+        val targetHeight = view.targetImageHeight()
+
+        val job = uiScope.launch {
+            try {
+                loadImage(targetWidth, targetHeight)
+                    .then { maybeImage ->
+                        val image = maybeImage as? HybridImage ?: return@then
+
+                        uiScope.launch {
+                            if (
+                                isDisposed ||
+                                !isCurrentRequest(view, generation) ||
+                                !view.isCurrentImageLoader(this@HybridImageLoader)
+                            ) {
+                                releaseHybridImageIfRenderOwned(image)
+                                removeCompletedJobs(view)
+                                return@launch
+                            }
+
+                            view.clearRenderBitmap("replace with HybridImage fallback")
+                            releaseDisplayedHybridImage(view)
+
+                            view.imageView.setImageBitmap(image.bitmap)
+
+                            if (!allowCaching) {
+                                displayedHybridImages[view] = image
+                            }
+
+                            removeCompletedJobs(view)
+                        }
+                    }
+            } catch (e: Throwable) {
+                Log.e(TAG, "Failed to request HybridImage!", e)
+                removeCompletedJobs(view)
+            }
+        }
+
+        addPendingJob(view, job)
+    }
+
+    private fun buildRenderCacheKey(targetWidth: Int, targetHeight: Int): String? {
+        val baseKey = renderCacheKey ?: return null
+        return "$baseKey@$targetWidth:$targetHeight"
+    }
+
+    private fun releaseOrRecycleBitmap(
+        bitmap: Bitmap,
+        cacheKey: String?,
+        reason: String
+    ) {
+        if (cacheKey != null) {
+            RenderBitmapMemoryCache.release(cacheKey)
+            return
+        }
+
+        recycleBitmap(bitmap, reason)
+    }
+
+    private fun addPendingJob(view: HybridImageView, job: Job) {
+        val jobs = pendingJobs[view] ?: mutableListOf<Job>().also { pendingJobs[view] = it }
+        jobs.add(job)
+    }
+
+    private fun removeCompletedJobs(view: HybridImageView) {
+        val jobs = pendingJobs[view] ?: return
+        jobs.removeAll { job -> job.isCompleted || job.isCancelled }
+
+        if (jobs.isEmpty()) {
+            pendingJobs.remove(view)
+        }
+    }
+
+    private fun nextGeneration(view: HybridImageView): Int {
+        val generation = (requestGenerations[view] ?: 0) + 1
+        requestGenerations[view] = generation
+        return generation
+    }
+
+    private fun invalidateRequest(view: HybridImageView) {
+        requestGenerations[view] = (requestGenerations[view] ?: 0) + 1
+    }
+
+    private fun isCurrentRequest(view: HybridImageView, generation: Int): Boolean {
+        return requestGenerations[view] == generation
+    }
+
+    private fun releaseDisplayedHybridImage(view: HybridImageView): Boolean {
+        val image = displayedHybridImages.remove(view) ?: return false
+        releaseHybridImageIfRenderOwned(image)
+        return true
+    }
+
+    private fun releaseAllDisplayedHybridImages() {
+        val images = displayedHybridImages.values.toList()
+        displayedHybridImages.clear()
+
+        images.forEach { image ->
+            releaseHybridImageIfRenderOwned(image)
+        }
+    }
+
+    private fun releaseHybridImageIfRenderOwned(image: HybridImage) {
+        if (allowCaching) {
+            return
+        }
+
+        try {
+            if (!image.bitmap.isRecycled) {
+                                image.dispose()
+            }
+        } catch (e: Throwable) {
+            Log.e(TAG, "Failed to release render-owned HybridImage Bitmap!", e)
+        }
+    }
+
+    private fun recycleBitmap(bitmap: Bitmap, reason: String) {
+        try {
+            if (!bitmap.isRecycled) {
+                bitmap.recycle()
+            }
+        } catch (e: Throwable) {
+            Log.e(TAG, "Failed to recycle Bitmap! reason=$reason", e)
         }
     }
 }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageLoaderFactory.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageLoaderFactory.kt
@@ -2,31 +2,59 @@ package com.margelo.nitro.image
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
-import com.margelo.nitro.core.ArrayBuffer
 import com.margelo.nitro.core.Promise
 
 @Keep
 @DoNotStrip
-class HybridImageLoaderFactory: HybridImageLoaderFactorySpec() {
+class HybridImageLoaderFactory : HybridImageLoaderFactorySpec() {
     private val factory = HybridImageFactory()
 
     override fun createFileImageLoader(filePath: String): HybridImageLoaderSpec {
-        return HybridImageLoader({ factory.loadFromFileAsync(filePath) }, true)
+        return HybridImageLoader(
+            loadImageFunc = { targetWidth, targetHeight ->
+                factory.loadFromFileAsync(filePath, targetWidth, targetHeight)
+            },
+            allowCaching = false,
+            renderCacheKey = filePath,
+            renderBitmapFunc = { targetWidth, targetHeight ->
+                factory.decodeBitmapFromFile(filePath, targetWidth, targetHeight)
+            }
+        )
     }
 
     override fun createResourceImageLoader(name: String): HybridImageLoaderSpec {
-        return HybridImageLoader({ factory.loadFromResourcesAsync(name) }, true)
+        return HybridImageLoader(
+            loadImageFunc = { _, _ ->
+                factory.loadFromResourcesAsync(name)
+            },
+            allowCaching = true
+        )
     }
 
     override fun createSymbolImageLoader(symbolName: String): HybridImageLoaderSpec {
-        return HybridImageLoader({ Promise.resolved(factory.loadFromSymbol(symbolName)) }, true)
+        return HybridImageLoader(
+            loadImageFunc = { _, _ ->
+                Promise.resolved(factory.loadFromSymbol(symbolName))
+            },
+            allowCaching = true
+        )
     }
 
     override fun createRawPixelDataImageLoader(data: RawPixelData): HybridImageLoaderSpec {
-        return HybridImageLoader({ factory.loadFromRawPixelDataAsync(data, false) }, true)
+        return HybridImageLoader(
+            loadImageFunc = { _, _ ->
+                factory.loadFromRawPixelDataAsync(data, false)
+            },
+            allowCaching = false
+        )
     }
 
     override fun createEncodedImageDataImageLoader(data: EncodedImageData): HybridImageLoaderSpec {
-        return HybridImageLoader({ factory.loadFromEncodedImageDataAsync(data) }, true)
+        return HybridImageLoader(
+            loadImageFunc = { _, _ ->
+                factory.loadFromEncodedImageDataAsync(data)
+            },
+            allowCaching = false
+        )
     }
 }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
@@ -1,6 +1,7 @@
 package com.margelo.nitro.image
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.util.Log
 import android.view.View
 import android.widget.ImageView
@@ -11,20 +12,34 @@ import com.margelo.nitro.views.RecyclableView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlin.math.max
+import kotlin.math.min
 
 @DoNotStrip
 @Keep
-class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableView {
+class HybridImageView(context: Context) : HybridNitroImageViewSpec(), RecyclableView {
     companion object {
         private const val TAG = "HybridImageView"
+
+        private const val DEFAULT_RENDER_TARGET_SIZE = 512
+        private const val MAX_FALLBACK_RENDER_TARGET_SIZE = 768
     }
+
     private val uiScope = CoroutineScope(Dispatchers.Main.immediate)
+
     private var resetImageBeforeLoad = false
+    private var currentRenderBitmap: Bitmap? = null
+    private var currentRenderOwner: HybridImageLoaderSpec? = null
+    private var currentRenderCacheKey: String? = null
 
     val imageView = CustomImageView(context) { visible ->
-        if (visible) onAppear()
-        else onDisappear()
+        if (visible) {
+            onAppear()
+        } else {
+            onDisappear()
+        }
     }
+
     override val view: View = imageView
 
     override var resizeMode: ResizeMode? = ResizeMode.CONTAIN
@@ -37,7 +52,23 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
 
     override var image: Variant_HybridImageSpec_HybridImageLoaderSpec? = null
         set(value) {
+            val oldLoader = field?.asSecondOrNull()
+            val newLoader = value?.asSecondOrNull()
+
+            if (oldLoader != null && oldLoader !== newLoader) {
+                try {
+                    oldLoader.dropImage(this)
+                } catch (e: Throwable) {
+                    Log.e(TAG, "Failed to drop previous ImageLoader!", e)
+                }
+            }
+
+            if (oldLoader !== newLoader) {
+                clearRenderBitmap("image prop changed")
+            }
+
             field = value
+
             uiScope.launch {
                 updateImage()
             }
@@ -45,13 +76,129 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
 
     override var recyclingKey: String? = null
         set(value) {
-            resetImageBeforeLoad = field != value
+            val changed = field != value
             field = value
+
+            
+            if (!changed) {
+                return
+            }
+
+            resetImageBeforeLoad = true
+
+            val imageLoader = image?.asSecondOrNull()
+            if (imageLoader != null) {
+                try {
+                    imageLoader.dropImage(this)
+                } catch (e: Throwable) {
+                    Log.e(TAG, "Failed to drop ImageLoader after recyclingKey change!", e)
+                }
+            }
+
+            clearRenderBitmap("recyclingKey changed")
         }
 
     override fun prepareForRecycle() {
         onDisappear()
-        imageView.setImageBitmap(null)
+        resetImageBeforeLoad = true
+        clearRenderBitmap("prepareForRecycle")
+    }
+
+    internal fun isCurrentImageLoader(loader: HybridImageLoaderSpec): Boolean {
+        return image?.asSecondOrNull() === loader
+    }
+
+    internal fun targetImageWidth(): Int {
+        val width = imageView.width
+        if (width > 0) {
+            return width
+        }
+
+        val measuredWidth = imageView.measuredWidth
+        if (measuredWidth > 0) {
+            return measuredWidth
+        }
+
+        val layoutWidth = imageView.layoutParams?.width ?: 0
+        if (layoutWidth > 0) {
+            return layoutWidth
+        }
+
+        return fallbackTargetSize()
+    }
+
+    internal fun targetImageHeight(): Int {
+        val height = imageView.height
+        if (height > 0) {
+            return height
+        }
+
+        val measuredHeight = imageView.measuredHeight
+        if (measuredHeight > 0) {
+            return measuredHeight
+        }
+
+        val layoutHeight = imageView.layoutParams?.height ?: 0
+        if (layoutHeight > 0) {
+            return layoutHeight
+        }
+
+        return fallbackTargetSize()
+    }
+
+    internal fun setRenderBitmap(
+        owner: HybridImageLoaderSpec,
+        bitmap: Bitmap,
+        cacheKey: String?
+    ) {
+        
+        if (!isCurrentImageLoader(owner)) {
+            releaseOrRecycleBitmap(
+                bitmap = bitmap,
+                cacheKey = cacheKey,
+                reason = "setRenderBitmap stale owner"
+            )
+            return
+        }
+
+        clearRenderBitmap("replace render bitmap")
+
+        currentRenderOwner = owner
+        currentRenderBitmap = bitmap
+        currentRenderCacheKey = cacheKey
+
+        imageView.setImageBitmap(bitmap)
+    }
+
+    internal fun clearRenderBitmap(reason: String): Boolean {
+        val bitmap = currentRenderBitmap
+        val cacheKey = currentRenderCacheKey
+        val hadBitmap = bitmap != null
+
+        currentRenderBitmap = null
+        currentRenderOwner = null
+        currentRenderCacheKey = null
+
+        if (hadBitmap) {
+            imageView.setImageDrawable(null)
+        }
+
+        if (bitmap != null) {
+            releaseOrRecycleBitmap(bitmap, cacheKey, reason)
+        }
+
+        return hadBitmap
+    }
+
+    internal fun clearRenderBitmapForOwner(
+        owner: HybridImageLoaderSpec,
+        reason: String
+    ): Boolean {
+        if (currentRenderOwner !== owner) {
+            return false
+        }
+
+        return clearRenderBitmap(reason)
     }
 
     private fun updateResizeMode() {
@@ -65,17 +212,24 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
     }
 
     private fun updateImage() {
-        image?.match(
+        val currentImage = image
+
+        if (currentImage == null) {
+            clearRenderBitmap("image set to null")
+            imageView.setImageDrawable(null)
+            return
+        }
+
+        currentImage.match(
             { actualImage: HybridImageSpec ->
-                // Image
-                if (actualImage is HybridImage) {
-                    imageView.setImageBitmap(actualImage.bitmap)
-                } else {
-                    throw Error("Image is a different type than HybridImage!")
-                }
+                clearRenderBitmap("switch to direct HybridImage")
+
+                val hybridImage = actualImage as? HybridImage
+                    ?: throw Error("Image is a different type than HybridImage!")
+
+                imageView.setImageBitmap(hybridImage.bitmap)
             },
             { _: HybridImageLoaderSpec ->
-                // ImageLoader
                 onAppear()
             }
         )
@@ -83,11 +237,13 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
 
     private fun onAppear() {
         val imageLoader = image?.asSecondOrNull() ?: return
+
         try {
             if (resetImageBeforeLoad) {
                 imageView.setImageDrawable(null)
                 resetImageBeforeLoad = false
             }
+
             imageLoader.requestImage(this)
         } catch (e: Throwable) {
             Log.e(TAG, "Failed to request Image!", e)
@@ -95,11 +251,51 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
     }
 
     private fun onDisappear() {
-        val imageLoader = image?.asSecondOrNull() ?: return
-        try {
-            imageLoader.dropImage(this)
-        } catch (e: Throwable) {
-            Log.e(TAG, "Failed to drop Image!", e)
+        val imageLoader = image?.asSecondOrNull()
+
+        if (imageLoader != null) {
+            try {
+                imageLoader.dropImage(this)
+            } catch (e: Throwable) {
+                Log.e(TAG, "Failed to drop Image!", e)
+            }
         }
+
+        clearRenderBitmap("onDisappear")
+    }
+
+    private fun releaseOrRecycleBitmap(
+        bitmap: Bitmap,
+        cacheKey: String?,
+        reason: String
+    ) {
+        if (cacheKey != null) {
+                        RenderBitmapMemoryCache.release(cacheKey)
+            return
+        }
+
+        recycleBitmap(bitmap, reason)
+    }
+
+    private fun recycleBitmap(bitmap: Bitmap, reason: String) {
+        try {
+            if (!bitmap.isRecycled) {
+                                bitmap.recycle()
+            }
+        } catch (e: Throwable) {
+            Log.e(TAG, "Failed to recycle view-owned Bitmap! reason=$reason", e)
+        }
+    }
+
+    private fun fallbackTargetSize(): Int {
+        val displayMetrics = imageView.resources.displayMetrics
+        val screenMax = max(displayMetrics.widthPixels, displayMetrics.heightPixels)
+
+        if (screenMax <= 0) {
+            return DEFAULT_RENDER_TARGET_SIZE
+        }
+
+        return min(screenMax, MAX_FALLBACK_RENDER_TARGET_SIZE)
+            .coerceAtLeast(DEFAULT_RENDER_TARGET_SIZE)
     }
 }


### PR DESCRIPTION
## Summary

Fixes Android native memory growth when rendering file-backed images through `NitroImage` / `ImageLoader`.

The previous Android file loader path could retain decoded image results and repeatedly decode images under high-churn rendering. In my app, rapidly switching or scrolling local images could grow native memory from a few hundred MB to over 1GB.

This PR adds an Android render-specific bitmap path for file-backed image loaders:

- file loaders no longer permanently cache decoded `HybridImage` results
- file render requests decode target-sized `Bitmap`s
- displayed render bitmaps are owned and released by `HybridImageView`
- stale async decode results are ignored/released
- repeated file/target decodes are coalesced
- a bounded render bitmap cache avoids repeatedly decoding the same image during rapid interaction

I verified the memory improvement on Android.

iOS may have a similar issue, but I intentionally omitted iOS changes because I do not currently have an iOS test device to validate the behavior or confirm a fix.