### PR TITLE
feat: Add configurable image memory cache size

### DIFF
--- a/packages/react-native-nitro-web-image/android/src/main/java/com/margelo/nitro/web/image/HybridWebImageFactory.kt
+++ b/packages/react-native-nitro-web-image/android/src/main/java/com/margelo/nitro/web/image/HybridWebImageFactory.kt
@@ -18,6 +18,12 @@ class HybridWebImageFactory: HybridWebImageFactorySpec() {
         get() = NitroModules.applicationContext ?: throw Error("No context - NitroModules.applicationContext was null!")
     private val imageLoader = ImageLoader(context)
 
+    override var maxMemoryBytes: Double
+        get() = (imageLoader.memoryCache?.maxSize ?: 0L).toDouble()
+        set(value) {
+            imageLoader.memoryCache?.maxSize = value.toLong()
+        }
+
     override fun createWebImageLoader(
         url: String,
         options: AsyncImageLoadOptions?

--- a/packages/react-native-nitro-web-image/ios/HybridWebImageFactory.swift
+++ b/packages/react-native-nitro-web-image/ios/HybridWebImageFactory.swift
@@ -11,6 +11,11 @@ import SDWebImage
 import NitroImage
 
 class HybridWebImageFactory: HybridWebImageFactorySpec {
+  var maxMemoryBytes: Double {
+    get { Double(SDImageCacheConfig.default.maxMemoryCost) }
+    set { SDImageCacheConfig.default.maxMemoryCost = UInt(max(0, newValue)) }
+  }
+
   func loadFromURLAsync(url urlString: String, options: AsyncImageLoadOptions?) throws -> Promise<any HybridImageSpec> {
     guard let url = URL(string: urlString) else {
       throw RuntimeError.error(withMessage: "URL string \"\(urlString)\" is not a valid URL!")

--- a/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JHybridWebImageFactorySpec.cpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JHybridWebImageFactorySpec.cpp
@@ -60,7 +60,15 @@ namespace margelo::nitro::web::image {
   }
 
   // Properties
-  
+  double JHybridWebImageFactorySpec::getMaxMemoryBytes() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getMaxMemoryBytes");
+    auto __result = method(_javaPart);
+    return __result;
+  }
+  void JHybridWebImageFactorySpec::setMaxMemoryBytes(double maxMemoryBytes) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(double /* maxMemoryBytes */)>("setMaxMemoryBytes");
+    method(_javaPart, maxMemoryBytes);
+  }
 
   // Methods
   std::shared_ptr<margelo::nitro::image::HybridImageLoaderSpec> JHybridWebImageFactorySpec::createWebImageLoader(const std::string& url, const std::optional<AsyncImageLoadOptions>& options) {

--- a/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JHybridWebImageFactorySpec.hpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JHybridWebImageFactorySpec.hpp
@@ -50,7 +50,8 @@ namespace margelo::nitro::web::image {
 
   public:
     // Properties
-    
+    double getMaxMemoryBytes() override;
+    void setMaxMemoryBytes(double maxMemoryBytes) override;
 
   public:
     // Methods

--- a/packages/react-native-nitro-web-image/nitrogen/generated/android/kotlin/com/margelo/nitro/web/image/HybridWebImageFactorySpec.kt
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/android/kotlin/com/margelo/nitro/web/image/HybridWebImageFactorySpec.kt
@@ -28,7 +28,11 @@ import com.margelo.nitro.core.HybridObject
 )
 abstract class HybridWebImageFactorySpec: HybridObject() {
   // Properties
-  
+  @get:DoNotStrip
+  @get:Keep
+  @set:DoNotStrip
+  @set:Keep
+  abstract var maxMemoryBytes: Double
 
   // Methods
   @DoNotStrip

--- a/packages/react-native-nitro-web-image/nitrogen/generated/ios/c++/HybridWebImageFactorySpecSwift.hpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/ios/c++/HybridWebImageFactorySpecSwift.hpp
@@ -76,7 +76,12 @@ namespace margelo::nitro::web::image {
 
   public:
     // Properties
-    
+    inline double getMaxMemoryBytes() noexcept override {
+      return _swiftPart.getMaxMemoryBytes();
+    }
+    inline void setMaxMemoryBytes(double maxMemoryBytes) noexcept override {
+      _swiftPart.setMaxMemoryBytes(std::forward<decltype(maxMemoryBytes)>(maxMemoryBytes));
+    }
 
   public:
     // Methods

--- a/packages/react-native-nitro-web-image/nitrogen/generated/ios/swift/HybridWebImageFactorySpec.swift
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/ios/swift/HybridWebImageFactorySpec.swift
@@ -11,7 +11,7 @@ import NitroModules
 /// See ``HybridWebImageFactorySpec``
 public protocol HybridWebImageFactorySpec_protocol: HybridObject {
   // Properties
-  
+  var maxMemoryBytes: Double { get set }
 
   // Methods
   func createWebImageLoader(url: String, options: AsyncImageLoadOptions?) throws -> (any HybridImageLoaderSpec)

--- a/packages/react-native-nitro-web-image/nitrogen/generated/ios/swift/HybridWebImageFactorySpec_cxx.swift
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/ios/swift/HybridWebImageFactorySpec_cxx.swift
@@ -122,7 +122,16 @@ open class HybridWebImageFactorySpec_cxx {
   }
 
   // Properties
-  
+  public final var maxMemoryBytes: Double {
+    @inline(__always)
+    get {
+      return self.__implementation.maxMemoryBytes
+    }
+    @inline(__always)
+    set {
+      self.__implementation.maxMemoryBytes = newValue
+    }
+  }
 
   // Methods
   @inline(__always)

--- a/packages/react-native-nitro-web-image/nitrogen/generated/shared/c++/HybridWebImageFactorySpec.cpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/shared/c++/HybridWebImageFactorySpec.cpp
@@ -14,6 +14,8 @@ namespace margelo::nitro::web::image {
     HybridObject::loadHybridMethods();
     // load custom methods/properties
     registerHybrids(this, [](Prototype& prototype) {
+      prototype.registerHybridGetter("maxMemoryBytes", &HybridWebImageFactorySpec::getMaxMemoryBytes);
+      prototype.registerHybridSetter("maxMemoryBytes", &HybridWebImageFactorySpec::setMaxMemoryBytes);
       prototype.registerHybridMethod("createWebImageLoader", &HybridWebImageFactorySpec::createWebImageLoader);
       prototype.registerHybridMethod("loadFromURLAsync", &HybridWebImageFactorySpec::loadFromURLAsync);
       prototype.registerHybridMethod("preload", &HybridWebImageFactorySpec::preload);

--- a/packages/react-native-nitro-web-image/nitrogen/generated/shared/c++/HybridWebImageFactorySpec.hpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/shared/c++/HybridWebImageFactorySpec.hpp
@@ -55,7 +55,8 @@ namespace margelo::nitro::web::image {
 
     public:
       // Properties
-      
+      virtual double getMaxMemoryBytes() = 0;
+      virtual void setMaxMemoryBytes(double maxMemoryBytes) = 0;
 
     public:
       // Methods

--- a/packages/react-native-nitro-web-image/src/specs/WebImageFactory.nitro.ts
+++ b/packages/react-native-nitro-web-image/src/specs/WebImageFactory.nitro.ts
@@ -87,6 +87,17 @@ export interface AsyncImageLoadOptions {
 export interface WebImageFactory
   extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
   /**
+   * The maximum size, in bytes, of the in-memory image cache used by
+   * {@linkcode WebImages}.
+   *
+   * On both platforms this defaults to the underlying library's own
+   * suggested size (Coil's `maxSizePercent` on Android, SDWebImage's
+   * default on iOS). Assigning a new value takes effect immediately and
+   * trims the cache down if it currently exceeds the new budget.
+   */
+  maxMemoryBytes: number
+
+  /**
    * Create a deferred {@linkcode ImageLoader} that loads the {@linkcode Image}
    * from the given {@linkcode url}.
    */


### PR DESCRIPTION
This PR adds the ability for a user to configure global cache size on Android and iOS using a custom value. 

Usage:

```typescript
import { WebImages } from 'react-native-nitro-web-image'

WebImages.maxMemoryBytes = 1024 * 1024 * 24 // 24mb on Android and iOS
```