### PR TITLE
chore: Upgrade release-it conventional changelog to 11.0.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@biomejs/biome": "^2.3.5",
         "@release-it-plugins/workspaces": "^5.0.3",
         "@release-it/bumper": "^7.0.5",
-        "@release-it/conventional-changelog": "^10.0.1",
+        "@release-it/conventional-changelog": "^11.0.0",
         "@tsconfig/react-native": "^2.0.3",
         "@types/jest": "^30.0.0",
         "@types/react": "^19.1.8",
@@ -21,7 +21,7 @@
     },
     "example": {
       "name": "NitroImageExample",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@react-navigation/bottom-tabs": "^7.4.6",
         "@react-navigation/native": "^7.1.17",
@@ -54,7 +54,7 @@
     },
     "packages/react-native-nitro-image": {
       "name": "react-native-nitro-image",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/react": "^19.0.6",
         "nitrogen": "0.35.5",
@@ -71,7 +71,7 @@
     },
     "packages/react-native-nitro-web-image": {
       "name": "react-native-nitro-web-image",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/react": "^19.0.6",
         "nitrogen": "0.35.5",
@@ -597,7 +597,7 @@
 
     "@release-it/bumper": ["@release-it/bumper@7.0.5", "", { "dependencies": { "@iarna/toml": "^3.0.0", "cheerio": "^1.0.0", "detect-indent": "7.0.1", "fast-glob": "^3.3.3", "ini": "^5.0.0", "js-yaml": "^4.1.0", "lodash-es": "^4.17.21", "semver": "^7.7.1" }, "peerDependencies": { "release-it": ">=18.0.0 || >=19.0.0" } }, "sha512-HCFMqDHreLYg4jjTWL//pW1GzZZMn3p7HDbwS2y7y5m0L6p8hEaOEixC3tEzwyVV7VP1VGjqxMvxfa360q8+Tg=="],
 
-    "@release-it/conventional-changelog": ["@release-it/conventional-changelog@10.0.6", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "concat-stream": "^2.0.0", "conventional-changelog": "^7.2.0", "conventional-changelog-angular": "^8.3.0", "conventional-changelog-conventionalcommits": "^9.3.0", "conventional-recommended-bump": "^11.2.0", "semver": "^7.7.4" }, "peerDependencies": { "release-it": "^18.0.0 || ^19.0.0" } }, "sha512-aUb0IkcsBTMcOH5PPQ9Jv9lEOOVu2+rSgkE1ny+dzsTziQm2BhDRAtaFK/dw/HflthuXMWrqhhyfJhAV1AOEPQ=="],
+    "@release-it/conventional-changelog": ["@release-it/conventional-changelog@11.0.0", "", { "dependencies": { "@conventional-changelog/git-client": "^2.7.0", "concat-stream": "^2.0.0", "conventional-changelog": "^7.2.0", "conventional-changelog-angular": "^8.3.1", "conventional-changelog-conventionalcommits": "^9.3.1", "conventional-recommended-bump": "^11.2.0", "semver": "^7.7.4" }, "peerDependencies": { "release-it": "^18.0.0 || ^19.0.0 || ^20.0.0" } }, "sha512-3/WyzObY+y+EejBt+J2vcojFPLUiGu14liRiaPWc0bNVluhRIsADeJ785Iq5ynnhdd1zcjMNh5lBmM/J6/KXig=="],
 
     "@sideway/address": ["@sideway/address@4.1.5", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@biomejs/biome": "^2.3.5",
     "@release-it-plugins/workspaces": "^5.0.3",
     "@release-it/bumper": "^7.0.5",
-    "@release-it/conventional-changelog": "^10.0.1",
+    "@release-it/conventional-changelog": "^11.0.0",
     "@tsconfig/react-native": "^2.0.3",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary
- Upgrade `@release-it/conventional-changelog` to `11.0.0`.
- Refresh `bun.lock`, including the existing workspace version metadata drift from `0.14.0` to `0.15.0`.

## Notes
- I did not force `release-it@20.0.1` because `@release-it-plugins/workspaces@5.0.3` still declares `release-it` peer support only through `^19`. Keeping `release-it@19.2.4` avoids an unsupported peer set.
- TODO: upgrade `release-it` itself once the workspaces plugin publishes a peer range that includes `^20`.

## Validation
- `PATH=/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:$PATH bunx release-it --dry-run --ci --no-github.release --no-npm.publish`
- Note: release-it dry-run mutates the root version in-place before skipping writes; that dry-run artifact was restored.