### PR TITLE
chore: Upgrade TypeScript to 6.0.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,12 +16,12 @@
         "react-native": "0.81.0",
         "react-native-builder-bob": "^0.37.0",
         "release-it": "^19.0.4",
-        "typescript": "5.8.3",
+        "typescript": "6.0.3",
       },
     },
     "example": {
       "name": "NitroImageExample",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@react-navigation/bottom-tabs": "^7.4.6",
         "@react-navigation/native": "^7.1.17",
@@ -49,19 +49,19 @@
         "@react-native/metro-config": "0.81.0",
         "@react-native/typescript-config": "0.81.0",
         "@types/react": "^19.1.0",
-        "typescript": "5.8.3",
+        "typescript": "6.0.3",
       },
     },
     "packages/react-native-nitro-image": {
       "name": "react-native-nitro-image",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/react": "^19.0.6",
         "nitrogen": "0.35.5",
         "react": "19.1.0",
         "react-native": "0.81.0",
         "react-native-nitro-modules": "0.35.5",
-        "typescript": "5.8.3",
+        "typescript": "6.0.3",
       },
       "peerDependencies": {
         "react": "*",
@@ -71,14 +71,14 @@
     },
     "packages/react-native-nitro-web-image": {
       "name": "react-native-nitro-web-image",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/react": "^19.0.6",
         "nitrogen": "0.35.5",
         "react": "19.1.0",
         "react-native": "0.81.0",
         "react-native-nitro-modules": "0.35.5",
-        "typescript": "5.8.3",
+        "typescript": "6.0.3",
       },
       "peerDependencies": {
         "react": "*",
@@ -1821,7 +1821,7 @@
 
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
-    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -17,6 +17,7 @@
     "forceConsistentCasingInFileNames": true,
     "lib": ["ESNext"],
     "module": "ESNext",
+    "ignoreDeprecations": "6.0",
     "moduleResolution": "Node",
     "noEmit": false,
     "noFallthroughCasesInSwitch": true,

--- a/example/package.json
+++ b/example/package.json
@@ -38,7 +38,7 @@
     "@react-native/metro-config": "0.81.0",
     "@react-native/typescript-config": "0.81.0",
     "@types/react": "^19.1.0",
-    "typescript": "5.8.3"
+    "typescript": "6.0.3"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-native": "0.81.0",
     "react-native-builder-bob": "^0.37.0",
     "release-it": "^19.0.4",
-    "typescript": "5.8.3"
+    "typescript": "6.0.3"
   },
   "release-it": {
     "npm": {

--- a/packages/react-native-nitro-image/package.json
+++ b/packages/react-native-nitro-image/package.json
@@ -62,7 +62,7 @@
     "react": "19.1.0",
     "react-native": "0.81.0",
     "react-native-nitro-modules": "0.35.5",
-    "typescript": "5.8.3"
+    "typescript": "6.0.3"
   },
   "peerDependencies": {
     "react": "*",

--- a/packages/react-native-nitro-web-image/package.json
+++ b/packages/react-native-nitro-web-image/package.json
@@ -61,7 +61,7 @@
     "react": "19.1.0",
     "react-native": "0.81.0",
     "react-native-nitro-modules": "0.35.5",
-    "typescript": "5.8.3"
+    "typescript": "6.0.3"
   },
   "peerDependencies": {
     "react": "*",


### PR DESCRIPTION
## Summary
- Upgrade TypeScript from `5.8.3` to `6.0.3` across the root, example app, and both packages.
- Add TypeScript 6's explicit `ignoreDeprecations: "6.0"` gate for the existing `moduleResolution: "Node"` setting.
- Refresh `bun.lock`, including the existing workspace version metadata drift from `0.14.0` to `0.15.0`.

## Notes
- I tested replacing `moduleResolution: "Node"` with `"Bundler"`, but that requires a larger workspace TS setup change because `react-native-nitro-web-image` imports `react-native-nitro-image` by package name during typecheck.
- TODO: migrate the package workspace to modern module resolution with project references or explicit package export typing, then remove the deprecation gate.

## Validation
- `PATH=/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:$PATH bun run build`
- `PATH=/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:$PATH bun run typecheck`