### PR TITLE
chore: Upgrade React Native tsconfig to 3.0.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@release-it-plugins/workspaces": "^5.0.3",
         "@release-it/bumper": "^7.0.5",
         "@release-it/conventional-changelog": "^11.0.0",
-        "@tsconfig/react-native": "^2.0.3",
+        "@tsconfig/react-native": "^3.0.9",
         "@types/jest": "^30.0.0",
         "@types/react": "^19.2.15",
         "react": "19.2.6",
@@ -629,7 +629,7 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.28.1", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g=="],
 
-    "@tsconfig/react-native": ["@tsconfig/react-native@2.0.3", "", {}, "sha512-jE58snEKBd9DXfyR4+ssZmYJ/W2mOSnNrvljR0aLyQJL9JKX6vlWELHkRjb3HBbcM9Uy0hZGijXbqEAjOERW2A=="],
+    "@tsconfig/react-native": ["@tsconfig/react-native@3.0.9", "", {}, "sha512-+PuvMuxb0OTHo/o04vEQI7LfUoiPH33pePvAH+qxf5ZPsRAVwtespj7LqysOTAYcsmRvjLPjik7V8pIcm84dEQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@release-it-plugins/workspaces": "^5.0.3",
     "@release-it/bumper": "^7.0.5",
     "@release-it/conventional-changelog": "^11.0.0",
-    "@tsconfig/react-native": "^2.0.3",
+    "@tsconfig/react-native": "^3.0.9",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.2.15",
     "react": "19.2.6",


### PR DESCRIPTION
## Summary
- Upgrade `@tsconfig/react-native` from `2.0.3` to `3.0.9`.
- Refresh `bun.lock`, including the existing workspace version metadata drift from `0.14.0` to `0.15.0`.

## Notes
- The v3 base expands ES2020-ES2022 library coverage and removes the old package-level exclude defaults.
- The local package tsconfigs already override emit and source settings, so no repo config migration was needed.

## Validation
- `PATH=/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:$PATH bun run build`