### PR TITLE
chore: Upgrade Nitro to 0.35.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "react-native-fast-image": "^8.6.3",
         "react-native-harness": "^1.0.0-alpha.25",
         "react-native-nitro-image": "workspace:*",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.9",
         "react-native-nitro-web-image": "workspace:*",
         "react-native-safe-area-context": "^5.8.0",
         "react-native-screens": "^4.25.2",
@@ -57,10 +57,10 @@
       "version": "0.15.0",
       "devDependencies": {
         "@types/react": "^19.2.15",
-        "nitrogen": "0.35.5",
+        "nitrogen": "0.35.9",
         "react": "19.2.6",
         "react-native": "0.85.3",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.9",
         "typescript": "6.0.3",
       },
       "peerDependencies": {
@@ -74,10 +74,10 @@
       "version": "0.15.0",
       "devDependencies": {
         "@types/react": "^19.2.15",
-        "nitrogen": "0.35.5",
+        "nitrogen": "0.35.9",
         "react": "19.2.6",
         "react-native": "0.85.3",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.9",
         "typescript": "6.0.3",
       },
       "peerDependencies": {
@@ -627,7 +627,7 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@ts-morph/common": ["@ts-morph/common@0.28.1", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g=="],
+    "@ts-morph/common": ["@ts-morph/common@0.29.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg=="],
 
     "@tsconfig/react-native": ["@tsconfig/react-native@2.0.3", "", {}, "sha512-jE58snEKBd9DXfyR4+ssZmYJ/W2mOSnNrvljR0aLyQJL9JKX6vlWELHkRjb3HBbcM9Uy0hZGijXbqEAjOERW2A=="],
 
@@ -1443,7 +1443,7 @@
 
     "new-github-release-url": ["new-github-release-url@2.0.0", "", { "dependencies": { "type-fest": "^2.5.1" } }, "sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ=="],
 
-    "nitrogen": ["nitrogen@0.35.5", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.5", "ts-morph": "^27.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-Ofl4aTW2rd44+hBcUwLXu01ViHikn2SDI7zOYc+6NcKSpnhoj42k1FwyvRj1QZPDMUT64Bwlb0DYw7Hrfd3BfQ=="],
+    "nitrogen": ["nitrogen@0.35.9", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.9", "ts-morph": "^28.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-Qbs45N/9VXYFg4u/nUF4EKw7qmbaVD0vABh5Rq6e3YT1MQP672/EBneMfNXvwOaTf8KW3pIxM01IlEdKS3f8JQ=="],
 
     "nocache": ["nocache@3.0.4", "", {}, "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw=="],
 
@@ -1609,7 +1609,7 @@
 
     "react-native-nitro-image": ["react-native-nitro-image@workspace:packages/react-native-nitro-image"],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.5", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-aa03UzC5dLg5qFfyBkVK+JGSwHTjmK7jUZzyRz11r1Yk9C/nJTFe59EeHPxxNNTagkiwQTM6p3sySgD/TDRC7Q=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.9", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yCO6eJ85SPPUo4a4an7H5oj6wPCSIT72fbjr5WZ/20n6zswaJ2gNNpnWtg2We0AZwkAOjSqkOJ0Vjc05p6kGiA=="],
 
     "react-native-nitro-web-image": ["react-native-nitro-web-image@workspace:packages/react-native-nitro-web-image"],
 
@@ -1791,7 +1791,7 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "ts-morph": ["ts-morph@27.0.2", "", { "dependencies": { "@ts-morph/common": "~0.28.1", "code-block-writer": "^13.0.3" } }, "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w=="],
+    "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,7 @@
     "react-native-fast-image": "^8.6.3",
     "react-native-harness": "^1.0.0-alpha.25",
     "react-native-nitro-image": "workspace:*",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.9",
     "react-native-nitro-web-image": "workspace:*",
     "react-native-safe-area-context": "^5.8.0",
     "react-native-screens": "^4.25.2"

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Color.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/Color.kt
@@ -43,7 +43,7 @@ data class Color(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       r,
       g,
       b,

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/EncodedImageData.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/EncodedImageData.kt
@@ -43,7 +43,7 @@ data class EncodedImageData(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       buffer,
       width,
       height,

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/RawPixelData.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/RawPixelData.kt
@@ -43,7 +43,7 @@ data class RawPixelData(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       buffer,
       width,
       height,

--- a/packages/react-native-nitro-image/package.json
+++ b/packages/react-native-nitro-image/package.json
@@ -58,10 +58,10 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.15",
-    "nitrogen": "0.35.5",
+    "nitrogen": "0.35.9",
     "react": "19.2.6",
     "react-native": "0.85.3",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.9",
     "typescript": "6.0.3"
   },
   "peerDependencies": {

--- a/packages/react-native-nitro-web-image/nitrogen/generated/android/kotlin/com/margelo/nitro/web/image/AsyncImageLoadOptions.kt
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/android/kotlin/com/margelo/nitro/web/image/AsyncImageLoadOptions.kt
@@ -71,7 +71,7 @@ data class AsyncImageLoadOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       priority,
       forceRefresh,
       cacheKey,

--- a/packages/react-native-nitro-web-image/package.json
+++ b/packages/react-native-nitro-web-image/package.json
@@ -57,10 +57,10 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.15",
-    "nitrogen": "0.35.5",
+    "nitrogen": "0.35.9",
     "react": "19.2.6",
     "react-native": "0.85.3",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.9",
     "typescript": "6.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- Upgrade `nitrogen` and `react-native-nitro-modules` from `0.35.5` to `0.35.9`.
- Regenerate Nitrogen output for both packages.
- Refresh `bun.lock`, including the existing workspace version metadata drift from `0.14.0` to `0.15.0`.

## Notes
- `nitrogen@0.35.9` depends on `react-native-nitro-modules@^0.35.9`, so these move together.
- Generated Android Kotlin data-class hash implementations now use `arrayOf<Any?>`, which avoids problematic type inference for nullable/mixed fields.

## Validation
- `PATH=/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:$PATH bun run specs`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" PATH="/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin:/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:$PATH" ./gradlew :app:compileDebugKotlin --no-daemon`

## Existing warnings
- Android compile still reports third-party deprecation warnings from `react-native-screens`, `react-native-safe-area-context`, and the RN 0.81 template, plus Gradle 9 compatibility warnings. Those are not introduced by this Nitro bump.