### PR TITLE
chore: Upgrade Android package toolchain to AGP 8.12.0

### DIFF
--- a/packages/react-native-nitro-image/android/build.gradle
+++ b/packages/react-native-nitro-image/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:8.10.1"
+    classpath "com.android.tools.build:gradle:8.12.0"
   }
 }
 

--- a/packages/react-native-nitro-image/android/gradle.properties
+++ b/packages/react-native-nitro-image/android/gradle.properties
@@ -1,5 +1,5 @@
-NitroImage_kotlinVersion=2.0.21
+NitroImage_kotlinVersion=2.1.20
 NitroImage_minSdkVersion=23
-NitroImage_targetSdkVersion=35
-NitroImage_compileSdkVersion=34
+NitroImage_targetSdkVersion=36
+NitroImage_compileSdkVersion=36
 NitroImage_ndkVersion=27.1.12297006

--- a/packages/react-native-nitro-web-image/android/build.gradle
+++ b/packages/react-native-nitro-web-image/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:8.10.1"
+    classpath "com.android.tools.build:gradle:8.12.0"
   }
 }
 
@@ -143,4 +143,3 @@ dependencies {
   implementation("io.coil-kt.coil3:coil-network-okhttp:3.3.0")
   implementation("io.coil-kt.coil3:coil-gif:3.3.0")
 }
-

--- a/packages/react-native-nitro-web-image/android/gradle.properties
+++ b/packages/react-native-nitro-web-image/android/gradle.properties
@@ -1,5 +1,5 @@
-NitroImage_kotlinVersion=2.0.21
+NitroImage_kotlinVersion=2.1.20
 NitroImage_minSdkVersion=23
-NitroImage_targetSdkVersion=35
-NitroImage_compileSdkVersion=34
+NitroImage_targetSdkVersion=36
+NitroImage_compileSdkVersion=36
 NitroImage_ndkVersion=27.1.12297006


### PR DESCRIPTION
## Summary
- Upgrade both Android package buildscript defaults from AGP 8.10.1 to 8.12.0.
- Align standalone package Kotlin defaults with the React Native 0.85 template value, 2.1.20.
- Align standalone package compile/target SDK defaults to 36 while keeping min SDK 23 and NDK 27.1.12297006.

## Validation
- PATH=/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/mrousavy/.codex/tmp/arg0/codex-arg0piPym5:/opt/homebrew/opt/binutils/bin:/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:/Users/mrousavy/.rbenv/shims:/opt/homebrew/opt/openjdk@17/bin:/Users/mrousavy/Library/Android/sdk/emulator:/Users/mrousavy/Library/Android/sdk/tools:/Users/mrousavy/Library/Android/sdk/tools/bin:/Users/mrousavy/Library/Android/sdk/platform-tools:/Applications/Codex.app/Contents/Resources bun install --ignore-scripts
- JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home PATH=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home/bin:/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/mrousavy/.codex/tmp/arg0/codex-arg0piPym5:/opt/homebrew/opt/binutils/bin:/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:/Users/mrousavy/.rbenv/shims:/opt/homebrew/opt/openjdk@17/bin:/Users/mrousavy/Library/Android/sdk/emulator:/Users/mrousavy/Library/Android/sdk/tools:/Users/mrousavy/Library/Android/sdk/tools/bin:/Users/mrousavy/Library/Android/sdk/platform-tools:/Applications/Codex.app/Contents/Resources ./gradlew :react-native-nitro-image:compileDebugKotlin :react-native-nitro-web-image:compileDebugKotlin --no-daemon

## Notes
- I did not move these package defaults to AGP 9.x/Kotlin 2.3 because React Native's included Gradle plugin still validates against Kotlin 2.1.x; the higher Kotlin metadata path failed in local validation.
- I kept NDK 27.1.12297006 because that is still the React Native template NDK and changing it would be a native ABI/toolchain migration, not a safe package-default bump.
