### PR TITLE
fix: Pin CFPropertyList for Ruby 3.2 compatibility

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -5,6 +5,8 @@ ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.16.2'
 gem 'concurrent-ruby', '< 1.3.4'
+# 3.0.9 declares ruby < 3.2, while xcodeproj 1.x does not allow CFPropertyList 4.x.
+gem 'CFPropertyList', '< 3.0.9'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
+    CFPropertyList (3.0.8)
     activesupport (6.1.7.10)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -96,6 +96,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  CFPropertyList (< 3.0.9)
   benchmark
   bigdecimal
   cocoapods (~> 1.16.2)


### PR DESCRIPTION
## Summary
- Pin `CFPropertyList` below `3.0.9` because that release declares `ruby < 3.2`.
- Regenerate `example/Gemfile.lock` to use `CFPropertyList 3.0.8`, the newest version compatible with Ruby 3.2 while still satisfying `xcodeproj` 1.x's `< 4.0` constraint.
- Deleted stale GitHub Actions Ruby 3.2 bundler caches that were keyed to the failing lockfile hash.

## Validation
- `eval "$(rbenv init - zsh)" && bundle _2.3.22_ check`
- `eval "$(rbenv init - zsh)" && bundle _2.3.22_ exec pod install --project-directory=ios`
- `BUNDLE_APP_CONFIG=/tmp/... BUNDLE_PATH=/tmp/.../vendor/bundle BUNDLE_DEPLOYMENT=true bundle _2.3.22_ install --jobs 3`
- `bundle exec ruby -e "spec = Gem::Specification.find_by_name(\"CFPropertyList\"); puts spec.required_ruby_version"` prints `>= 0` for 3.0.8.