### PR TITLE
fix: stabilize Android Harness image tests

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup JDK 17
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 17
           java-package: jdk
 

--- a/.github/workflows/harness-android.yml
+++ b/.github/workflows/harness-android.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: 17
           java-package: jdk
 

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImage.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImage.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Rect
+import android.graphics.RectF
 import android.os.Build
 import androidx.annotation.Keep
 import androidx.core.graphics.createBitmap
@@ -14,6 +15,7 @@ import com.margelo.nitro.core.ArrayBuffer
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.image.extensions.compressInMemory
 import com.margelo.nitro.image.extensions.isGPU
+import com.margelo.nitro.image.extensions.isRawPixelDataAccessible
 import com.margelo.nitro.image.extensions.pixelFormat
 import com.margelo.nitro.image.extensions.saveToFile
 import com.margelo.nitro.image.extensions.toFilePath
@@ -22,6 +24,7 @@ import com.margelo.nitro.image.extensions.toCpuAccessible
 import com.margelo.nitro.image.extensions.toMutable
 import java.io.File
 import java.nio.ByteBuffer
+import kotlin.math.ceil
 
 @Suppress("ConvertSecondaryConstructorToPrimary")
 @Keep
@@ -54,13 +57,13 @@ class HybridImage: HybridImageSpec {
         } else {
             // Copy the data into a CPU buffer (ByteBuffer)
             var bitmap = bitmap
-            if (bitmap.isGPU) {
-                // If this is a GPU-based bitmap (but we cannot use GPU), copy it to a CPU Bitmap first
+            if (!bitmap.isRawPixelDataAccessible) {
+                // If this is a GPU-based or otherwise unsupported Bitmap config, normalize it first.
                 bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, false)
             }
             val buffer = bitmap.toByteBuffer()
             val arrayBuffer = ArrayBuffer.wrap(buffer)
-            return RawPixelData(arrayBuffer, width, height, bitmap.pixelFormat)
+            return RawPixelData(arrayBuffer, bitmap.width.toDouble(), bitmap.height.toDouble(), bitmap.pixelFormat)
         }
     }
     override fun toRawPixelDataAsync(allowGpu: Boolean?): Promise<RawPixelData> {
@@ -86,8 +89,16 @@ class HybridImage: HybridImageSpec {
         // 2. Create a rotation Matrix
         val matrix = Matrix()
         matrix.setRotate(degrees.toFloat(), source.width / 2f, source.height / 2f)
+        // Rotating around the center can move the image into negative coordinates.
+        // Map the original bounds through the rotation to measure the full output size,
+        // then translate the matrix back so the rotated image starts at (0, 0).
+        val bounds = RectF(0f, 0f, source.width.toFloat(), source.height.toFloat())
+        matrix.mapRect(bounds)
+        matrix.postTranslate(-bounds.left, -bounds.top)
         // 3. Create a new blank Bitmap as our output
-        val destination = createBitmap(bitmap.width, bitmap.height)
+        val destinationWidth = ceil(bounds.width()).toInt().coerceAtLeast(1)
+        val destinationHeight = ceil(bounds.height()).toInt().coerceAtLeast(1)
+        val destination = createBitmap(destinationWidth, destinationHeight)
         // 4. Draw the Bitmap to our destination
         Canvas(destination).apply {
             drawBitmap(source, matrix, null)

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/extensions/Bitmap+isRawPixelDataAccessible.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/extensions/Bitmap+isRawPixelDataAccessible.kt
@@ -1,0 +1,7 @@
+package com.margelo.nitro.image.extensions
+
+import android.graphics.Bitmap
+import com.margelo.nitro.image.PixelFormat
+
+val Bitmap.isRawPixelDataAccessible: Boolean
+    get() = !isGPU && pixelFormat != PixelFormat.UNKNOWN


### PR DESCRIPTION
## Summary
- switch Android Build and Harness workflows from Zulu to Temurin JDK 17 so setup-java reaches Gradle/Harness reliably
- normalize unsupported CPU bitmap configs before exporting raw pixel data so Android does not report `unknown` for RGB_565 blank images
- rotate Android bitmaps into expanded destination bounds instead of clipping into the source dimensions

## Verification
- #151 Build Android Example App passed
- #151 Harness Android passed
- local: `JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew :app:assembleDebug --no-daemon --build-cache -PreactNativeArchitectures=x86_64 --console=plain`