### PR TITLE
ci: use Temurin for Android JDK setup

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup JDK 17
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 17
           java-package: jdk
 

--- a/.github/workflows/harness-android.yml
+++ b/.github/workflows/harness-android.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: 17
           java-package: jdk
 


### PR DESCRIPTION
## Summary
- switch the Android Build and Harness workflows from Zulu to Temurin JDK 17
- avoids repeated `actions/setup-java` failures while resolving Zulu with upstream `error code: 520`

## Stacking
- #153 is CI-only and can reach Gradle/Harness with Temurin
- standalone Harness Android still fails on main's existing image bugs, as expected
- #151 is stacked on this branch and validates the combination: Build Android and Harness Android pass there

## Verification
- #153 Build Android passed with Temurin
- #151 Build Android passed
- #151 Harness Android passed