### PR TITLE
Fix R/B channel swap in Android raw pixel data

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/extensions/Bitmap+fromRawPixelData.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/extensions/Bitmap+fromRawPixelData.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import androidx.core.graphics.createBitmap
 import com.margelo.nitro.image.PixelFormat
 import com.margelo.nitro.image.RawPixelData
+import java.nio.ByteOrder
 import java.nio.IntBuffer
 
 private data class Swizzle(val r: Int, val g: Int, val b: Int, val a: Int, val bpp: Int)
@@ -26,6 +27,8 @@ private val SW = mapOf(
 fun bitmapFromRawPixelData(data: RawPixelData, allowGpu: Boolean): Bitmap {
     if (allowGpu) {
         // FAST PATH: Try using GPU Buffer (HardwareBuffer) if it is one. This is zero-copy!
+        // A HardwareBuffer is self-describing (it carries its own pixel format),
+        // so data.pixelFormat is not consulted here.
         if (data.buffer.isHardwareBuffer && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val bitmap = Bitmap.wrapHardwareBuffer(data.buffer.getHardwareBuffer(), ColorSpace.get(ColorSpace.Named.SRGB))
             if (bitmap != null) {
@@ -39,13 +42,16 @@ fun bitmapFromRawPixelData(data: RawPixelData, allowGpu: Boolean): Bitmap {
     val totalLength = data.buffer.size
     val bytesPerRow = totalLength / h
     val bytesPerPixel = bytesPerRow / w
-    if (data.pixelFormat == PixelFormat.BGRA && bytesPerPixel == 4) {
-        // FAST PATH: Source came from ARGB_8888 Bitmap bytes -> reinterpret as Ints with little endian
-        val buffer = data.buffer.getBuffer(false).slice().order(java.nio.ByteOrder.LITTLE_ENDIAN)
-        val source = buffer.asIntBuffer()
+    if (data.pixelFormat == PixelFormat.RGBA && bytesPerPixel == 4 &&
+        ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) {
+        // FAST PATH: An ARGB_8888 Bitmap's memory is physically [R, G, B, A] bytes -
+        // the "ARGB" in the config name only describes the getPixel()/setPixel()
+        // ColorInt packing, not the memory layout. copyPixelsFromBuffer() is a raw
+        // memory copy, so RGBA input can be copied in as-is.
+        val buffer = data.buffer.getBuffer(false).slice()
         val bitmap = createBitmap(w, h, Bitmap.Config.ARGB_8888)
         bitmap.isPremultiplied = true
-        bitmap.copyPixelsFromBuffer(source)
+        bitmap.copyPixelsFromBuffer(buffer)
         return bitmap
     }
 
@@ -67,7 +73,11 @@ fun bitmapFromRawPixelData(data: RawPixelData, allowGpu: Boolean): Bitmap {
         val rr = if (srcPremul || a == 255) r else (r * a + 127) / 255
         val gg = if (srcPremul || a == 255) g else (g * a + 127) / 255
         val bb = if (srcPremul || a == 255) b_ else (b_ * a + 127) / 255
-        return (a shl 24) or (rr shl 16) or (gg shl 8) or bb
+        // These Ints are written with copyPixelsFromBuffer(), which is a raw memory copy -
+        // so they must match ARGB_8888's physical pixel word (R in the least significant
+        // byte, i.e. 0xAABBGGRR), NOT the 0xAARRGGBB ColorInt packing that
+        // getPixel()/setPixel() use.
+        return (a shl 24) or (bb shl 16) or (gg shl 8) or rr
     }
 
     var di = 0

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/extensions/Bitmap+pixelFormat.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/extensions/Bitmap+pixelFormat.kt
@@ -10,17 +10,20 @@ val Bitmap.pixelFormat: PixelFormat
     get() {
         when (config) {
             Bitmap.Config.ARGB_8888 -> {
-                // On Android, ARGB_8888 defines memory layout inside an Int, not the byte order.
-                // So where iOS would define Pixel Format ARGB as byte order [A, R, G, B],
-                // Android instead defines the Pixel Format ARGB as 0xAARRGGBB (32-bit Int) -
-                // which - if read on a little-endian machine, is reversed ([B, G, R, A]).
+                // Despite its name, ARGB_8888 does NOT describe the byte order in memory.
+                // "0xAARRGGBB" is only the ColorInt packing used by getPixel()/setPixel().
+                // Each pixel is actually stored as a 32-bit word with R in the least
+                // significant byte (0xAABBGGRR). toRawPixelData() exports via
+                // copyPixelsToBuffer() - a raw memory copy - so the exported bytes are the
+                // physical memory layout of that word.
                 if (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) {
-                    // almost every device nowadays is little endian
-                    return PixelFormat.BGRA
+                    // almost every device nowadays is little endian:
+                    // the 0xAABBGGRR word lays out as [R, G, B, A] bytes.
+                    return PixelFormat.RGBA
                 } else {
                     // no devices use big endian anymore, but we keep this to highlight
-                    // why ARGB becomes BGRA on little endian.
-                    return PixelFormat.ARGB
+                    // that the 0xAABBGGRR word would lay out as [A, B, G, R] bytes there.
+                    return PixelFormat.ABGR
                 }
             }
             Bitmap.Config.HARDWARE -> {

--- a/packages/react-native-nitro-image/src/index.ts
+++ b/packages/react-native-nitro-image/src/index.ts
@@ -4,7 +4,13 @@ export * from './ImageUtils'
 export * from './loadImage'
 export { NativeNitroImage } from './NativeNitroImage'
 export { NitroImage, type NitroImageProps } from './NitroImage'
-export type { Image } from './specs/Image.nitro'
+export type {
+  EncodedImageData,
+  Image,
+  ImageFormat,
+  PixelFormat,
+  RawPixelData,
+} from './specs/Image.nitro'
 export type { ImageLoader } from './specs/ImageLoader.nitro'
 
 export * from './useImage'

--- a/packages/react-native-nitro-image/src/specs/Image.nitro.ts
+++ b/packages/react-native-nitro-image/src/specs/Image.nitro.ts
@@ -16,11 +16,11 @@ import type { HybridObject } from 'react-native-nitro-modules'
  *
  * `A` means alpha, `X` means placeholder - skip alpha.
  *
- * @note On some platforms (such as Android) Pixel Formats are specified as the order of pixels inside an `Int`.
- * For example, [`Bitmap.Config.ARGB_888`](https://developer.android.com/reference/android/graphics/Bitmap.Config)
- * means "`0xAARRGGBB`" when read as an `Int`, but when read as bytes, it depends on the OS' endianess. On most
- * modern OS (ARM64), the byte order is little-endian, which would flip the `ARGB_8888` format to be read as
- * `[B, G, R, A]` instead. This is why a `Bitmap` that is in `ARGB_8888` config will return `BGRA` here in Nitro Image.
+ * @note Native config names do not always describe the byte order in memory.
+ * For example, Android's [`Bitmap.Config.ARGB_8888`](https://developer.android.com/reference/android/graphics/Bitmap.Config)
+ * is named after the "`0xAARRGGBB`" `Int` packing used by `getPixel()`/`setPixel()` - but the Bitmap's actual
+ * memory is laid out as `[R, G, B, A]` bytes. Since raw pixel data is exported as a raw
+ * memory copy, a `Bitmap` in `ARGB_8888` config returns `RGBA` here in Nitro Image.
  */
 export type PixelFormat =
   | 'ARGB'
@@ -70,20 +70,22 @@ export interface Image
 
   /**
    * Returns an {@linkcode ArrayBuffer} containing the raw pixel data of the Image.
-   * @note Raw pixel data is either in {@linkcode PixelFormat | 'ARGB'} or
-   * {@linkcode PixelFormat | 'BGRA'} format, depending on the OS' endianess.
+   * @note The returned {@linkcode PixelFormat} describes the literal byte order in memory -
+   * always read it instead of assuming a fixed format. It is typically
+   * {@linkcode PixelFormat | 'RGBA'} on Android (the memory layout of `ARGB_8888` Bitmaps),
+   * and {@linkcode PixelFormat | 'BGRA'} on iOS - but it can differ per image.
    * @param allowGpu If `allowGpu` is set to `true`, the returned buffer might
    * be a `HardwareBuffer` (a GPU-buffer) on Android. By default, it is `false`.
    * @example
    * ```ts
-   * const rawData = image.toRawArrayBuffer()
+   * const rawData = image.toRawPixelData()
    * const data = new Uint8Array(rawData.buffer)
    * let r, g, b
-   * if (rawData.pixelFormat === 'bgra') {
+   * if (rawData.pixelFormat === 'BGRA') {
    *   r = data[2]
    *   g = data[1]
    *   b = data[0]
-   * } else {
+   * } else if (rawData.pixelFormat === 'RGBA') {
    *   r = data[0]
    *   g = data[1]
    *   b = data[2]


### PR DESCRIPTION
## What

On Android, an `ARGB_8888` Bitmap's memory is physically `[R, G, B, A]` bytes. The `ARGB` in the config name only describes the `getPixel()`/`setPixel()` ColorInt packing (`0xAARRGGBB`), not the layout that `copyPixelsFromBuffer`/`copyPixelsToBuffer` (raw memory copies) use.

Two coupled bugs made every raw pixel roundtrip swap red and blue on little-endian devices:

- **`loadFromRawPixelData` (slow path)** packed ColorInt-ordered words and wrote them with `copyPixelsFromBuffer`, so on little-endian they landed as `B, G, R, A` bytes.
- **`toRawPixelData`** labeled `ARGB_8888` exports as `BGRA`, but the raw-copied bytes are physically `R, G, B, A`.

## Fix

- Pack the physical pixel word (`0xAABBGGRR`) in the slow path.
- Label `ARGB_8888` exports as `RGBA`.
- Re-key the byte-identical raw-copy fast path from `BGRA` to `RGBA`, so `BGRA` input now goes through the corrected swizzle path.
- Export `PixelFormat`, `RawPixelData`, `EncodedImageData` and `ImageFormat` from the entrypoint.

## Note for consumers

This is a behavior fix. Code that worked around the swap by mislabeling RGBA bytes as `'BGRA'` on Android must drop that workaround (for example react-native-vision-camera's harness tests).

Regression tests covering this land separately so they can validate all of the raw pixel data fixes together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
