### PR TITLE
Fix iOS pixel format label for default byte order

### DIFF
--- a/packages/react-native-nitro-image/ios/Extensions/CGImage+getPixelFormat.swift
+++ b/packages/react-native-nitro-image/ios/Extensions/CGImage+getPixelFormat.swift
@@ -12,8 +12,11 @@ extension CGImage {
   private var isLittleEndian: Bool {
     switch self.byteOrderInfo {
     case .orderDefault:
-      // iOS uses little endian by default
-      return true
+      // The "default" byte order has big-endian semantics: components are stored
+      // in memory in exactly the order alphaInfo names them - e.g. premultipliedLast
+      // + orderDefault is physically [R, G, B, A] bytes. This is a property of the
+      // Core Graphics format description, unrelated to the host CPU's endianness.
+      return false
     case .order16Little, .order32Little:
       return true
     case .order16Big, .order32Big:
@@ -37,10 +40,12 @@ extension CGImage {
       // ___A
       return self.isLittleEndian ? .abgr : .rgba
     case .noneSkipFirst:
-      // X___
+      // X___ - the padding byte is reported as alpha on purpose: Apple's decoders
+      // and renderers fill it with 0xFF, so the bytes read correctly as opaque alpha,
+      // and consumers don't need to special-case the X formats.
       return self.isLittleEndian ? .bgra : .argb
     case .noneSkipLast:
-      // ___X
+      // ___X - see above, reported as alpha on purpose.
       return self.isLittleEndian ? .abgr : .rgba
     case .none:
       // ___


### PR DESCRIPTION
## What

`CGImage`'s `.orderDefault` byte order has big-endian semantics: components are stored in memory in exactly the order `alphaInfo` names them (for example `premultipliedLast + orderDefault` is physically `[R, G, B, A]`, the classic RGBA context). This is a property of the Core Graphics format description, not the host CPU's endianness.

`getPixelFormat` treated `.orderDefault` as little-endian, so `toRawPixelData` reported reversed pixel format labels (R and B swapped) for ImageIO-decoded images such as PNG/JPEG loads. Camera-frame-style images that carry an explicit `byteOrder32Little` were unaffected.

## Fix

Treat `.orderDefault` as big-endian so the reported `pixelFormat` matches the physical bytes. Also documents that the `noneSkip` padding byte is intentionally reported as alpha (Apple's decoders fill it with `0xFF`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
