### PR TITLE
Support 24-bit RGB/BGR raw pixel data on iOS

### DIFF
--- a/packages/react-native-nitro-image/ios/Extensions/UIImage+fromRawPixelData.swift
+++ b/packages/react-native-nitro-image/ios/Extensions/UIImage+fromRawPixelData.swift
@@ -10,7 +10,7 @@ import CoreGraphics
 import NitroModules
 
 extension CGBitmapInfo {
-  init(rawPixelData: RawPixelData) throws {
+  init(pixelFormat: PixelFormat) throws {
     let alphaFirst = CGImageAlphaInfo.premultipliedFirst.rawValue
     let alphaLast  = CGImageAlphaInfo.premultipliedLast.rawValue
     let noneFirst  = CGImageAlphaInfo.noneSkipFirst.rawValue
@@ -18,7 +18,7 @@ extension CGBitmapInfo {
     let o32L       = CGBitmapInfo.byteOrder32Little.rawValue
     let o32B       = CGBitmapInfo.byteOrder32Big.rawValue
 
-    switch rawPixelData.pixelFormat {
+    switch pixelFormat {
     case .argb: self.init(rawValue: alphaFirst | o32B)   // ARGB
     case .bgra: self.init(rawValue: alphaFirst | o32L)   // BGRA
     case .abgr: self.init(rawValue: alphaLast  | o32L)   // ABGR
@@ -29,13 +29,40 @@ extension CGBitmapInfo {
     case .xbgr: self.init(rawValue: noneLast   | o32L)   // XBGR (opaque)
     case .rgbx: self.init(rawValue: noneLast   | o32B)   // RGBX (opaque)
 
-    case .rgb:  self.init(rawValue: CGImageAlphaInfo.none.rawValue | o32B) // 24-bit RGB
-    case .bgr:  self.init(rawValue: CGImageAlphaInfo.none.rawValue | o32L) // 24-bit BGR
+    case .rgb:
+      // 24-bit formats are stored as plain sequential bytes - the 16/32-bit
+      // byteOrder flags don't apply, so "no alpha, default order" is [R, G, B].
+      self.init(rawValue: CGImageAlphaInfo.none.rawValue)
+    case .bgr:
+      // Core Graphics has no 24-bit BGR format - byteOrder32Little has no effect
+      // on 24-bit data. Callers must expand BGR to 32-bit BGRX first.
+      throw RuntimeError.error(withMessage: "Core Graphics does not support 24-bit BGR - expand the data to BGRX first!")
 
     case .unknown:
       throw RuntimeError.error(withMessage: "Cannot initialize CGBitmapInfo with .unknown PixelFormat!")
     }
   }
+}
+
+/**
+ * Expands 3-byte [B, G, R] pixel data to 4-byte [B, G, R, 0xFF] (BGRX) pixel data,
+ * because Core Graphics does not support any 24-bit BGR format.
+ */
+private func expandBGRToBGRX(_ bgr: ArrayBuffer, width: Int, height: Int) throws -> ArrayBuffer {
+  let pixelCount = width * height
+  guard bgr.size >= pixelCount * 3 else {
+    throw RuntimeError.error(withMessage: "BGR buffer is too small! (Size: \(bgr.size), Expected: \(pixelCount * 3))")
+  }
+  let bgrx = ArrayBuffer.allocate(size: pixelCount * 4)
+  let source = bgr.data
+  let destination = bgrx.data
+  for i in 0 ..< pixelCount {
+    destination[i * 4]     = source[i * 3]     // B
+    destination[i * 4 + 1] = source[i * 3 + 1] // G
+    destination[i * 4 + 2] = source[i * 3 + 2] // R
+    destination[i * 4 + 3] = 0xFF              // X (opaque)
+  }
+  return bgrx
 }
 
 extension CGDataProvider {
@@ -71,15 +98,22 @@ extension UIImage {
   convenience init(fromRawPixelData data: RawPixelData) throws {
     let width = Int(data.width)
     let height = Int(data.height)
-    let bytesPerPixel = 4
-    let bytesPerRow = width * bytesPerPixel
     let bitsPerComponent = 8
 
-    let buffer = data.buffer.asOwning()
+    var buffer = data.buffer.asOwning()
+    var pixelFormat = data.pixelFormat
+    if pixelFormat == .bgr {
+      // Core Graphics has no 24-bit BGR format - expand to 32-bit BGRX first.
+      buffer = try expandBGRToBGRX(buffer, width: width, height: height)
+      pixelFormat = .bgrx
+    }
+    let bytesPerPixel = pixelFormat == .rgb ? 3 : 4
+    let bytesPerRow = width * bytesPerPixel
+
     let dataProvider = try CGDataProvider.fromArrayBuffer(buffer)
 
     let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let bitmapInfo = try CGBitmapInfo(rawPixelData: data)
+    let bitmapInfo = try CGBitmapInfo(pixelFormat: pixelFormat)
 
     guard let cg = CGImage(
       width: width,


### PR DESCRIPTION
## What

`UIImage(fromRawPixelData:)` hardcoded 4 bytes per pixel, so loading a 3-byte `RGB` or `BGR` buffer computed `bytesPerRow` as `width * 4` against a `width * height * 3` buffer and failed to create a `CGImage`.

## Fix

- Derive bytes per pixel from the resolved pixel format.
- Build a native 24-bit `CGImage` for `RGB`.
- Expand `BGR` to `BGRX` first, because Core Graphics has no 24-bit BGR format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
