### PR TITLE
feat: Update Nitro to 0.36.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "example": {
       "name": "NitroImageExample",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@react-navigation/bottom-tabs": "^7.16.2",
         "@react-navigation/native": "^7.2.5",
@@ -30,7 +30,7 @@
         "react-native-fast-image": "^8.6.3",
         "react-native-harness": "^1.3.0",
         "react-native-nitro-image": "workspace:*",
-        "react-native-nitro-modules": "0.35.9",
+        "react-native-nitro-modules": "0.36.5",
         "react-native-nitro-web-image": "workspace:*",
         "react-native-safe-area-context": "^5.8.0",
         "react-native-screens": "^4.25.2",
@@ -54,13 +54,13 @@
     },
     "packages/react-native-nitro-image": {
       "name": "react-native-nitro-image",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "devDependencies": {
         "@types/react": "^19.2.15",
-        "nitrogen": "0.35.9",
+        "nitrogen": "0.36.5",
         "react": "19.2.3",
         "react-native": "0.85.3",
-        "react-native-nitro-modules": "0.35.9",
+        "react-native-nitro-modules": "0.36.5",
         "typescript": "6.0.3",
       },
       "peerDependencies": {
@@ -71,13 +71,13 @@
     },
     "packages/react-native-nitro-web-image": {
       "name": "react-native-nitro-web-image",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "devDependencies": {
         "@types/react": "^19.2.15",
-        "nitrogen": "0.35.9",
+        "nitrogen": "0.36.5",
         "react": "19.2.3",
         "react-native": "0.85.3",
-        "react-native-nitro-modules": "0.35.9",
+        "react-native-nitro-modules": "0.36.5",
         "typescript": "6.0.3",
       },
       "peerDependencies": {
@@ -1555,7 +1555,7 @@
 
     "new-github-release-url": ["new-github-release-url@2.0.0", "", { "dependencies": { "type-fest": "^2.5.1" } }, "sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ=="],
 
-    "nitrogen": ["nitrogen@0.35.9", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.9", "ts-morph": "^28.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-Qbs45N/9VXYFg4u/nUF4EKw7qmbaVD0vABh5Rq6e3YT1MQP672/EBneMfNXvwOaTf8KW3pIxM01IlEdKS3f8JQ=="],
+    "nitrogen": ["nitrogen@0.36.5", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.36.5", "ts-morph": "^28.0.0", "yargs": "^18.0.0", "zod": "^4.4.3" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-PvlHrBVaoKEaD6CCUCG7om8MTvLeh4ZSDxHoRx2YiEWUVXPXrRN9NwMn1gjie9Bd91jHA3dYMF7no9Eme4txMA=="],
 
     "nocache": ["nocache@3.0.4", "", {}, "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw=="],
 
@@ -1723,7 +1723,7 @@
 
     "react-native-nitro-image": ["react-native-nitro-image@workspace:packages/react-native-nitro-image"],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.9", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yCO6eJ85SPPUo4a4an7H5oj6wPCSIT72fbjr5WZ/20n6zswaJ2gNNpnWtg2We0AZwkAOjSqkOJ0Vjc05p6kGiA=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.36.5", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-SJby84+hovD70JmQ1fq+56tw3oapJeChehUqXA4Gqjm+ktJhMAcj8LGwoAjStSOUwRaK7czbzBPB0Widj+EDoQ=="],
 
     "react-native-nitro-web-image": ["react-native-nitro-web-image@workspace:packages/react-native-nitro-web-image"],
 
@@ -2513,7 +2513,7 @@
 
     "nitrogen/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
-    "nitrogen/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "nitrogen/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -61,7 +61,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - NitroModules (0.35.9):
+  - NitroModules (0.36.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2284,7 +2284,7 @@ SPEC CHECKSUMS:
   hermes-engine: ef561c35b1325a953b54456ddbd27ee0faf01ba4
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   NitroImage: 2f592086cbdecbbaa1c10dd97e0cdd43b1bb0817
-  NitroModules: 16bc17a076b12304d608f7c915b9d321f56dfc19
+  NitroModules: 452230d9b63c6c3f59dd97eeaa27ec3449271d4a
   NitroWebImage: ca414f829cae44174179ea0e8ff28df75f40f08e
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc

--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,7 @@
     "react-native-fast-image": "^8.6.3",
     "react-native-harness": "^1.3.0",
     "react-native-nitro-image": "workspace:*",
-    "react-native-nitro-modules": "0.35.9",
+    "react-native-nitro-modules": "0.36.5",
     "react-native-nitro-web-image": "workspace:*",
     "react-native-safe-area-context": "^5.8.0",
     "react-native-screens": "^4.25.2"

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JColor.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JColor.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "Color" and the the Kotlin data class "Color".
+   * The C++ JNI bridge between the C++ struct "Color" and the Kotlin data class "Color".
    */
   struct JColor final: public jni::JavaClass<JColor> {
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JEncodedImageData.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JEncodedImageData.hpp
@@ -20,7 +20,7 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "EncodedImageData" and the the Kotlin data class "EncodedImageData".
+   * The C++ JNI bridge between the C++ struct "EncodedImageData" and the Kotlin data class "EncodedImageData".
    */
   struct JEncodedImageData final: public jni::JavaClass<JEncodedImageData> {
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageFormat.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JImageFormat.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "ImageFormat" and the the Kotlin enum "ImageFormat".
+   * The C++ JNI bridge between the C++ enum "ImageFormat" and the Kotlin enum "ImageFormat".
    */
   struct JImageFormat final: public jni::JavaClass<JImageFormat> {
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPixelFormat.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JPixelFormat.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "PixelFormat" and the the Kotlin enum "PixelFormat".
+   * The C++ JNI bridge between the C++ enum "PixelFormat" and the Kotlin enum "PixelFormat".
    */
   struct JPixelFormat final: public jni::JavaClass<JPixelFormat> {
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JRawPixelData.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JRawPixelData.hpp
@@ -20,7 +20,7 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "RawPixelData" and the the Kotlin data class "RawPixelData".
+   * The C++ JNI bridge between the C++ struct "RawPixelData" and the Kotlin data class "RawPixelData".
    */
   struct JRawPixelData final: public jni::JavaClass<JRawPixelData> {
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/c++/JResizeMode.hpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/c++/JResizeMode.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::image {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "ResizeMode" and the the Kotlin enum "ResizeMode".
+   * The C++ JNI bridge between the C++ enum "ResizeMode" and the Kotlin enum "ResizeMode".
    */
   struct JResizeMode final: public jni::JavaClass<JResizeMode> {
   public:

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageFactorySpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import dalvik.annotation.optimization.FastNative
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.ArrayBuffer
 import com.margelo.nitro.core.HybridObject
@@ -92,6 +93,7 @@ abstract class HybridImageFactorySpec: HybridObject() {
   @Keep
   protected open class CxxPart(javaPart: HybridImageFactorySpec): HybridObject.CxxPart(javaPart) {
     // C++ JHybridImageFactorySpec::CxxPart::initHybrid(...)
+    @FastNative
     external override fun initHybrid(): HybridData
   }
   override fun createCxxPart(): CxxPart {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageLoaderFactorySpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageLoaderFactorySpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import dalvik.annotation.optimization.FastNative
 import com.margelo.nitro.core.HybridObject
 
 /**
@@ -58,6 +59,7 @@ abstract class HybridImageLoaderFactorySpec: HybridObject() {
   @Keep
   protected open class CxxPart(javaPart: HybridImageLoaderFactorySpec): HybridObject.CxxPart(javaPart) {
     // C++ JHybridImageLoaderFactorySpec::CxxPart::initHybrid(...)
+    @FastNative
     external override fun initHybrid(): HybridData
   }
   override fun createCxxPart(): CxxPart {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageLoaderSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageLoaderSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import dalvik.annotation.optimization.FastNative
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.HybridObject
 
@@ -51,6 +52,7 @@ abstract class HybridImageLoaderSpec: HybridObject() {
   @Keep
   protected open class CxxPart(javaPart: HybridImageLoaderSpec): HybridObject.CxxPart(javaPart) {
     // C++ JHybridImageLoaderSpec::CxxPart::initHybrid(...)
+    @FastNative
     external override fun initHybrid(): HybridData
   }
   override fun createCxxPart(): CxxPart {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import dalvik.annotation.optimization.FastNative
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.ArrayBuffer
 import com.margelo.nitro.core.HybridObject
@@ -118,6 +119,7 @@ abstract class HybridImageSpec: HybridObject() {
   @Keep
   protected open class CxxPart(javaPart: HybridImageSpec): HybridObject.CxxPart(javaPart) {
     // C++ JHybridImageSpec::CxxPart::initHybrid(...)
+    @FastNative
     external override fun initHybrid(): HybridData
   }
   override fun createCxxPart(): CxxPart {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageUtilsSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridImageUtilsSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import dalvik.annotation.optimization.FastNative
 import com.margelo.nitro.core.ArrayBuffer
 import com.margelo.nitro.core.HybridObject
 
@@ -53,6 +54,7 @@ abstract class HybridImageUtilsSpec: HybridObject() {
   @Keep
   protected open class CxxPart(javaPart: HybridImageUtilsSpec): HybridObject.CxxPart(javaPart) {
     // C++ JHybridImageUtilsSpec::CxxPart::initHybrid(...)
+    @FastNative
     external override fun initHybrid(): HybridData
   }
   override fun createCxxPart(): CxxPart {

--- a/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridNitroImageViewSpec.kt
+++ b/packages/react-native-nitro-image/nitrogen/generated/android/kotlin/com/margelo/nitro/image/HybridNitroImageViewSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import dalvik.annotation.optimization.FastNative
 import com.margelo.nitro.core.HybridObject
 import com.margelo.nitro.views.HybridView
 
@@ -57,6 +58,7 @@ abstract class HybridNitroImageViewSpec: HybridView() {
   @Keep
   protected open class CxxPart(javaPart: HybridNitroImageViewSpec): HybridObject.CxxPart(javaPart) {
     // C++ JHybridNitroImageViewSpec::CxxPart::initHybrid(...)
+    @FastNative
     external override fun initHybrid(): HybridData
   }
   override fun createCxxPart(): CxxPart {

--- a/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridNitroImageViewComponent.cpp
+++ b/packages/react-native-nitro-image/nitrogen/generated/shared/c++/views/HybridNitroImageViewComponent.cpp
@@ -79,7 +79,7 @@ namespace margelo::nitro::image::views {
 
   HybridNitroImageViewComponentDescriptor::HybridNitroImageViewComponentDescriptor(const react::ComponentDescriptorParameters& parameters)
     : ConcreteComponentDescriptor(parameters,
-                                  react::RawPropsParser(/* enableJsiParser */ true)) {}
+                                  react::RawPropsParser()) {}
 
   std::shared_ptr<const react::Props> HybridNitroImageViewComponentDescriptor::cloneProps(const react::PropsParserContext& context,
                                                                                           const std::shared_ptr<const react::Props>& props,

--- a/packages/react-native-nitro-image/package.json
+++ b/packages/react-native-nitro-image/package.json
@@ -58,10 +58,10 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.15",
-    "nitrogen": "0.35.9",
+    "nitrogen": "0.36.5",
     "react": "19.2.3",
     "react-native": "0.85.3",
-    "react-native-nitro-modules": "0.35.9",
+    "react-native-nitro-modules": "0.36.5",
     "typescript": "6.0.3"
   },
   "peerDependencies": {

--- a/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JAsyncImageLoadOptions.hpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JAsyncImageLoadOptions.hpp
@@ -20,7 +20,7 @@ namespace margelo::nitro::web::image {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "AsyncImageLoadOptions" and the the Kotlin data class "AsyncImageLoadOptions".
+   * The C++ JNI bridge between the C++ struct "AsyncImageLoadOptions" and the Kotlin data class "AsyncImageLoadOptions".
    */
   struct JAsyncImageLoadOptions final: public jni::JavaClass<JAsyncImageLoadOptions> {
   public:

--- a/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JAsyncImagePriority.hpp
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/android/c++/JAsyncImagePriority.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::web::image {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "AsyncImagePriority" and the the Kotlin enum "AsyncImagePriority".
+   * The C++ JNI bridge between the C++ enum "AsyncImagePriority" and the Kotlin enum "AsyncImagePriority".
    */
   struct JAsyncImagePriority final: public jni::JavaClass<JAsyncImagePriority> {
   public:

--- a/packages/react-native-nitro-web-image/nitrogen/generated/android/kotlin/com/margelo/nitro/web/image/HybridWebImageFactorySpec.kt
+++ b/packages/react-native-nitro-web-image/nitrogen/generated/android/kotlin/com/margelo/nitro/web/image/HybridWebImageFactorySpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.web.image
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import dalvik.annotation.optimization.FastNative
 import com.margelo.nitro.image.HybridImageLoaderSpec
 import com.margelo.nitro.image.HybridImageSpec
 import com.margelo.nitro.core.Promise
@@ -53,6 +54,7 @@ abstract class HybridWebImageFactorySpec: HybridObject() {
   @Keep
   protected open class CxxPart(javaPart: HybridWebImageFactorySpec): HybridObject.CxxPart(javaPart) {
     // C++ JHybridWebImageFactorySpec::CxxPart::initHybrid(...)
+    @FastNative
     external override fun initHybrid(): HybridData
   }
   override fun createCxxPart(): CxxPart {

--- a/packages/react-native-nitro-web-image/package.json
+++ b/packages/react-native-nitro-web-image/package.json
@@ -57,10 +57,10 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.15",
-    "nitrogen": "0.35.9",
+    "nitrogen": "0.36.5",
     "react": "19.2.3",
     "react-native": "0.85.3",
-    "react-native-nitro-modules": "0.35.9",
+    "react-native-nitro-modules": "0.36.5",
     "typescript": "6.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
- Potentially faster initialization for Images (all HybridObjects) on Android
- Fixes `react::RawPropsParser(/* enableJsiParser */ true))` new constructor in react-native