### PR TITLE
fix(android): build renderInto's destination Rect from edges, not size

### DIFF
--- a/example/__tests__/image-transforms.harness.ts
+++ b/example/__tests__/image-transforms.harness.ts
@@ -53,3 +53,28 @@ describe('Image - mirrorHorizontally', () => {
     expect(mirrored.height).toBe(20)
   })
 })
+
+describe('Image - renderInto', () => {
+  it('draws at the given position, scaled to the given size', () => {
+    const white = { r: 1, g: 1, b: 1, a: 1 }
+    const red = { r: 1, g: 0, b: 0, a: 1 }
+    const base = Images.createBlankImage(100, 100, true, white)
+    const sprite = Images.createBlankImage(10, 10, true, red)
+
+    // Drawn at (20, 20) sized 60x60, so red covers 20..80 on both axes.
+    const raw = base.renderInto(sprite, 20, 20, 60, 60).toRawPixelData()
+
+    // Red has two near-zero channels, white has none - in any channel order.
+    const bytesPerPixel =
+      new Uint8Array(raw.buffer).length / (raw.width * raw.height)
+    const isRed = (x: number, y: number) => {
+      const offset = (y * raw.width + x) * bytesPerPixel
+      const pixel = new Uint8Array(raw.buffer, offset, bytesPerPixel)
+      return pixel.filter((channel) => channel < 100).length === 2
+    }
+
+    expect(isRed(25, 25)).toBe(true) // near corner, inside either way
+    expect(isRed(75, 75)).toBe(true) // far corner, only inside if 60x60 is a size
+    expect(isRed(95, 95)).toBe(false) // background
+  })
+})

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImage.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImage.kt
@@ -212,8 +212,8 @@ class HybridImage: HybridImageSpec {
             // 3. Prepare the Bitmap we want to draw into our Canvas
             val rect = Rect(x.toInt(),
                 y.toInt(),
-                width.toInt(),
-                height.toInt())
+                (x + width).toInt(),
+                (y + height).toInt())
 
             // 4. Make sure we can draw the Bitmap (HARDWARE isn't CPU accessible)
             val drawable = newImage.bitmap.toCpuAccessible()


### PR DESCRIPTION
## What

`HybridImage.renderInto()` builds its destination rectangle as `Rect(x, y, width, height)`. `android.graphics.Rect` takes `(left, top, right, bottom)`, so `width`/`height` land in the edge slots: the drawn size becomes `(width − x) × (height − y)`, and once `x >= width` the rect inverts and nothing is drawn at all. Only `x = y = 0` is unaffected, which is why existing usage looks fine.

These arguments are a size, not edges:

- `Image.nitro.ts` documents them as one — "at the given `x` and `y` position, scaled to the given `width` and `height`"
- iOS implements them that way — `NativeImage.swift` uses `CGRect(x:y:width:height:)`
- the API that does take edges is named for it — `crop(startX, startY, endX, endY)`

Drawing a 200x200 sprite into a 400x400 image at `(100, 100)`: documented 200x200, Android drew 100x100. At `(300, 300)`, nothing was drawn.

## Fix

```kotlin
val rect = Rect(x.toInt(), y.toInt(), (x + width).toInt(), (y + height).toInt())
```

No API change, iOS untouched.

## Test

`image-transforms.harness.ts` covered `resize`, `crop`, `rotate` and `mirrorHorizontally` but had no `renderInto` case, which is why this went unnoticed. Added one: a red sprite drawn at `(20, 20)` sized `60x60`, three sampled pixels. The pixel reader is local to the test — the equivalent helper in `image-raw-pixel-data.harness.ts` is file-local and not exported.

On `main` it fails on the far corner (`expected false to be true` — the pixel at (75, 75) is still background); with the fix applied it passes. Verified by stashing the Kotlin change, rebuilding the app and re-running, so the test is known to exercise the changed code path.

Run locally on an arm64 API 35 emulator rather than CI's x86_64. No iOS code is touched, so the iOS harness is left to CI.

## Note for consumers

This is a behaviour fix. Code that compensated for it on Android by passing `(x + width, y + height)` must drop the compensation.

Standalone repro, without cloning the monorepo: https://github.com/dazakdev/nitro-image-renderinto-repro

Right now it looks like this:

<img width="411" height="912" alt="image" src="https://github.com/user-attachments/assets/c1abf255-bb91-4916-bf24-8ff0b53402d7" />

<img width="410" height="891" alt="image" src="https://github.com/user-attachments/assets/517a4705-87b3-4ba2-9cc3-c9b4f8ee727e" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)
