### PR TITLE
fix: discard stale Image loads for recycled/re-bound views

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageLoader.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageLoader.kt
@@ -33,10 +33,15 @@ class HybridImageLoader(
 
     override fun requestImage(forView: HybridNitroImageViewSpec) {
         val view = forView as? HybridImageView ?: return
+        // Start a new request - this invalidates any request that is still in flight for this view.
+        val token = view.beginImageRequest()
 
         loadImage().then { maybeImage ->
             val image = maybeImage as? HybridImage ?: return@then
             uiScope.launch {
+                // The view might have been recycled or re-bound to a different image while we
+                // were loading - in that case this result is stale and must not be applied.
+                if (!view.isImageRequestValid(token)) return@launch
                 view.imageView.setImageBitmap(image.bitmap)
             }
         }
@@ -44,6 +49,9 @@ class HybridImageLoader(
 
     override fun dropImage(forView: HybridNitroImageViewSpec) {
         val view = forView as? HybridImageView ?: return
+        // Invalidate any in-flight request so it doesn't paint into the view after we cleared it.
+        view.cancelImageRequest()
+
         uiScope.launch {
             view.imageView.setImageDrawable(null)
         }

--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
@@ -11,6 +11,7 @@ import com.margelo.nitro.views.RecyclableView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicInteger
 
 @DoNotStrip
 @Keep
@@ -20,6 +21,7 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
     }
     private val uiScope = CoroutineScope(Dispatchers.Main.immediate)
     private var resetImageBeforeLoad = false
+    private val imageRequestToken = AtomicInteger(0)
 
     val imageView = CustomImageView(context) { visible ->
         if (visible) onAppear()
@@ -48,6 +50,24 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
             resetImageBeforeLoad = field != value
             field = value
         }
+
+    /**
+     * Starts a new Image request, invalidating any request that is still in flight.
+     * Returns a token identifying the new request.
+     */
+    fun beginImageRequest(): Int = imageRequestToken.incrementAndGet()
+
+    /**
+     * Invalidates the currently pending Image request (if any), without starting a new one.
+     */
+    fun cancelImageRequest() {
+        imageRequestToken.incrementAndGet()
+    }
+
+    /**
+     * Whether [token] still identifies this view's most recently started Image request.
+     */
+    fun isImageRequestValid(token: Int): Boolean = imageRequestToken.get() == token
 
     override fun prepareForRecycle() {
         onDisappear()

--- a/packages/react-native-nitro-image/ios/HybridImageLoader.swift
+++ b/packages/react-native-nitro-image/ios/HybridImageLoader.swift
@@ -42,17 +42,30 @@ class HybridImageLoader: HybridImageLoaderSpec {
 
   func requestImage(forView view: any HybridNitroImageViewSpec) throws {
     guard let view = view as? NativeImageView else { return }
+    let imageView = view.imageView
+    // Start a new request - this invalidates any request that is still in flight for this view.
+    let tracker = view as? ImageRequestTracking
+    let token = tracker?.beginImageRequest()
+
     try loadImage()
-      .then { image in
+      .then { [weak tracker] image in
         guard let image = image as? NativeImage else { return }
         DispatchQueue.runOnMain {
-          view.imageView.image = image.uiImage
+          if let token {
+            // The view might have been recycled or re-bound to a different image while we
+            // were loading - in that case this result is stale and must not be applied.
+            guard let tracker, tracker.isImageRequestValid(token) else { return }
+          }
+          imageView.image = image.uiImage
         }
       }
   }
 
   func dropImage(forView view: any HybridNitroImageViewSpec) throws {
     guard let view = view as? NativeImageView else { return }
+    // Invalidate any in-flight request so it doesn't paint into the view after we cleared it.
+    (view as? ImageRequestTracking)?.cancelImageRequest()
+
     DispatchQueue.runOnMain {
       view.imageView.image = nil
     }

--- a/packages/react-native-nitro-image/ios/HybridImageView.swift
+++ b/packages/react-native-nitro-image/ios/HybridImageView.swift
@@ -12,6 +12,8 @@ import NitroModules
 class HybridImageView: HybridNitroImageViewSpec {
   let view = CustomImageView()
   private var resetImageBeforeLoad = false
+  private let imageRequestLock = NSLock()
+  private var currentImageRequestToken = 0
 
   override init() {
     super.init()
@@ -103,6 +105,28 @@ extension HybridImageView: ViewLifecycleDelegate {
   func willHide() {
     guard let imageLoader else { return }
     try? imageLoader.dropImage(forView: self)
+  }
+}
+
+// Implementation to discard results of Image loads that are no longer relevant
+extension HybridImageView: ImageRequestTracking {
+  func beginImageRequest() -> Int {
+    imageRequestLock.lock()
+    defer { imageRequestLock.unlock() }
+    currentImageRequestToken += 1
+    return currentImageRequestToken
+  }
+
+  func cancelImageRequest() {
+    imageRequestLock.lock()
+    defer { imageRequestLock.unlock() }
+    currentImageRequestToken += 1
+  }
+
+  func isImageRequestValid(_ token: Int) -> Bool {
+    imageRequestLock.lock()
+    defer { imageRequestLock.unlock() }
+    return currentImageRequestToken == token
   }
 }
 

--- a/packages/react-native-nitro-image/ios/Public/ImageRequestTracking.swift
+++ b/packages/react-native-nitro-image/ios/Public/ImageRequestTracking.swift
@@ -1,0 +1,34 @@
+//
+//  ImageRequestTracking.swift
+//  Pods
+//
+//  Created by Marc Rousavy on 20.08.26.
+//
+
+/**
+ * A protocol for image views that can track which image request is currently relevant.
+ *
+ * Image loading is asynchronous, and a view can be recycled - or asked to load a
+ * different image - while a load is still in flight. Without tracking, the stale load
+ * would resolve later and overwrite whatever the view is supposed to show now.
+ *
+ * Views conforming to this protocol get such stale results discarded.
+ * `NativeImageView`s that don't conform still work, they just can't cancel.
+ */
+public protocol ImageRequestTracking: AnyObject {
+  /**
+   * Starts a new image request and returns a token identifying it.
+   * Any previously started request for this view is invalidated.
+   */
+  func beginImageRequest() -> Int
+
+  /**
+   * Invalidates the currently pending image request (if any), without starting a new one.
+   */
+  func cancelImageRequest()
+
+  /**
+   * Whether `token` still identifies this view's most recently started request.
+   */
+  func isImageRequestValid(_ token: Int) -> Bool
+}


### PR DESCRIPTION
`HybridImageLoader.requestImage(forView:)` kicked off an async load and then unconditionally assigned the result to the view's `imageView`, with no cancellation and no way to tell whether that result was still wanted.

In a list, that means:

1. Cell A starts loading image A into view V.
2. V is recycled and re-bound to cell B, showing image B.
3. Load A resolves and overwrites V with image A.

`prepareForRecycle()` clearing the image doesn't help, because it runs *before* the stale completion lands. The same happens without recycling whenever the `image` prop changes mid-load and the two loads resolve out of order (easy to hit, since a cached `HybridImageLoader` resolves instantly while an uncached one doesn't).

This adds a monotonic per-view request token:

- `beginImageRequest()` starts a request and invalidates any in-flight one
- `cancelImageRequest()` invalidates without starting a new one (called from `dropImage`)
- `isImageRequestValid(token)` is checked right before the result is applied

On iOS this is exposed as a new `ImageRequestTracking` protocol next to `NativeImageView`, so third-party image views can opt into it. Views that don't conform keep working exactly as before, they just don't get cancellation.

`react-native-nitro-web-image` is unaffected - SDWebImage and Coil already scope requests to the target view.

## Testing

Not verified on device - CI builds cover compilation.