### PR TITLE
fix: reset all view state in prepareForRecycle

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
@@ -51,6 +51,13 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
 
     override fun prepareForRecycle() {
         onDisappear()
+        // Reset all props back to their defaults. Props are only re-applied to a recycled view
+        // if they are actually provided by the next consumer, so anything we keep here would
+        // silently leak into the next cell.
+        image = null
+        recyclingKey = null
+        resizeMode = ResizeMode.CONTAIN
+        resetImageBeforeLoad = false
         imageView.setImageBitmap(null)
     }
 

--- a/packages/react-native-nitro-image/ios/HybridImageView.swift
+++ b/packages/react-native-nitro-image/ios/HybridImageView.swift
@@ -110,6 +110,13 @@ extension HybridImageView: ViewLifecycleDelegate {
 extension HybridImageView: RecyclableView {
   func prepareForRecycle() {
     willHide()
+    // Reset all props back to their defaults. Props are only re-applied to a recycled view
+    // if they are actually provided by the next consumer, so anything we keep here would
+    // silently leak into the next cell.
+    image = nil
+    recyclingKey = nil
+    resizeMode = nil
+    resetImageBeforeLoad = false
     view.image = nil
   }
 }


### PR DESCRIPTION
`prepareForRecycle()` cleared the underlying `UIImageView`/`ImageView`, but left the HybridView's own props (`image`, `recyclingKey`, `resizeMode`, `resetImageBeforeLoad`) at the recycled cell's values.

Props are only pushed onto a recycled view if the next consumer actually *provides* them (the generated updater checks `isProvided()`), so whatever we don't reset leaks into the next cell:

- **`resizeMode`** - mount a `<NitroImage resizeMode="stretch" />`, recycle it into a `<NitroImage />` with no `resizeMode`, and the second one silently renders stretched instead of falling back to the default.
- **`image`** - the recycled view still points at the *previous* cell's `HybridImageLoader`. Re-attaching to a window fires `onAppear()`/`willShow()`, which re-requests that old loader. Fabric's mount order (props before insert) usually hides this, but nothing here enforces it.
- **`recyclingKey`** - if a recycled view happens to be reused with the same key the previous occupant had, `resetImageBeforeLoad` stays `false` and the blank-before-load behaviour is skipped.

Resetting them makes a recycled view behave identically to a freshly created one. Each platform is reset to its own initial value (`ResizeMode.CONTAIN` on Android, `nil` on iOS), so this is not changing default rendering.

`resetImageBeforeLoad` is reset last on purpose - assigning `recyclingKey` runs its setter, which would otherwise leave it `true`.

## Testing

Not verified on device - CI builds cover compilation.