### PR TITLE
fix: don't drop the Image twice per recycle

### DIFF
--- a/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
+++ b/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/HybridImageView.kt
@@ -20,6 +20,7 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
     }
     private val uiScope = CoroutineScope(Dispatchers.Main.immediate)
     private var resetImageBeforeLoad = false
+    private var hasRequestedImage = false
 
     val imageView = CustomImageView(context) { visible ->
         if (visible) onAppear()
@@ -88,6 +89,7 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
                 imageView.setImageDrawable(null)
                 resetImageBeforeLoad = false
             }
+            hasRequestedImage = true
             imageLoader.requestImage(this)
         } catch (e: Throwable) {
             Log.e(TAG, "Failed to request Image!", e)
@@ -95,6 +97,10 @@ class HybridImageView(context: Context): HybridNitroImageViewSpec(), RecyclableV
     }
 
     private fun onDisappear() {
+        // Only drop if we actually have an outstanding request - recycling detaches the view
+        // from the window first, so otherwise `dropImage(..)` would run twice per recycle.
+        if (!hasRequestedImage) return
+        hasRequestedImage = false
         val imageLoader = image?.asSecondOrNull() ?: return
         try {
             imageLoader.dropImage(this)

--- a/packages/react-native-nitro-image/ios/HybridImageView.swift
+++ b/packages/react-native-nitro-image/ios/HybridImageView.swift
@@ -12,6 +12,7 @@ import NitroModules
 class HybridImageView: HybridNitroImageViewSpec {
   let view = CustomImageView()
   private var resetImageBeforeLoad = false
+  private var hasRequestedImage = false
 
   override init() {
     super.init()
@@ -97,10 +98,15 @@ extension HybridImageView: ViewLifecycleDelegate {
       view.image = nil
       resetImageBeforeLoad = false
     }
+    hasRequestedImage = true
     try? imageLoader.requestImage(forView: self)
   }
 
   func willHide() {
+    // Only drop if we actually have an outstanding request - recycling removes the view
+    // from its window first, so otherwise `dropImage(forView:)` would run twice per recycle.
+    guard hasRequestedImage else { return }
+    hasRequestedImage = false
     guard let imageLoader else { return }
     try? imageLoader.dropImage(forView: self)
   }


### PR DESCRIPTION
`prepareForRecycle()` calls `onDisappear()`/`willHide()` directly, but the view has already been removed from its window at that point, which fired the visibility callback and called it once already. So every recycle ran `imageLoader.dropImage(..)` twice.

Harmless with the built-in `HybridImageLoader` (it just nils the image), but `dropImage` is part of the public `HybridImageLoaderSpec` - any third-party loader that refcounts, cancels, or releases a cache entry in `dropImage` gets an unbalanced call.

Fixed by tracking whether there is an outstanding request, making the drop idempotent. The direct call in `prepareForRecycle()` is kept rather than removed, so we still drop correctly if a view is ever recycled while attached.

## Testing

Not verified on device - CI builds cover compilation.